### PR TITLE
ProviderKeepers in World can be registered by plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <version>1.10.19</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.agrona</groupId>
       <artifactId>agrona</artifactId>
       <version>0.9.20</version>

--- a/src/main/java/io/vlingo/actors/MailboxProviderKeeper.java
+++ b/src/main/java/io/vlingo/actors/MailboxProviderKeeper.java
@@ -7,79 +7,10 @@
 
 package io.vlingo.actors;
 
-import java.util.HashMap;
-import java.util.Map;
-
-final class MailboxProviderKeeper {
-  private final Map<String,MailboxProviderInfo> mailboxProviderInfos;
-
-  MailboxProviderKeeper() {
-    this.mailboxProviderInfos = new HashMap<>();
-  }
-
-  Mailbox assignMailbox(final String name, final int hashCode) {
-    MailboxProviderInfo info = mailboxProviderInfos.get(name);
-
-    if (info == null) {
-      throw new IllegalStateException("No registered MailboxProvider named " + name);
-    }
-
-    return info.mailboxProvider.provideMailboxFor(hashCode);
-  }
-
-  void close() {
-    for (final MailboxProviderInfo info : mailboxProviderInfos.values()) {
-      info.mailboxProvider.close();
-    }
-  }
-
-  String findDefault() {
-    for (final MailboxProviderInfo info : mailboxProviderInfos.values()) {
-      if (info.isDefault) {
-        return info.name;
-      }
-    }
-
-    throw new IllegalStateException("No registered default MailboxProvider.");
-  }
-
-  void keep(final String name, boolean isDefault, final MailboxProvider mailboxProvider) {
-    if (mailboxProviderInfos.isEmpty()) {
-      isDefault = true;
-    }
-    
-    if (isDefault) {
-      undefaultCurrentDefault();
-    }
-
-    mailboxProviderInfos.put(name, new MailboxProviderInfo(name, mailboxProvider, isDefault));
-  }
-
-  void undefaultCurrentDefault() {
-    for (final String key : mailboxProviderInfos.keySet()) {
-      final MailboxProviderInfo info = mailboxProviderInfos.get(key);
-
-      if (info.isDefault) {
-        mailboxProviderInfos.put(key, new MailboxProviderInfo(info.name, info.mailboxProvider, false));
-      }
-    }
-  }
-
-  boolean isValidMailboxName(final String candidateMailboxName) {
-    final MailboxProviderInfo info = mailboxProviderInfos.get(candidateMailboxName);
-
-    return info != null;
-  }
-
-  final class MailboxProviderInfo {
-    final boolean isDefault;
-    final MailboxProvider mailboxProvider;
-    final String name;
-
-    MailboxProviderInfo(final String name, final MailboxProvider mailboxProvider, final boolean isDefault) {
-      this.name = name;
-      this.mailboxProvider = mailboxProvider;
-      this.isDefault = isDefault;
-    }
-  }
+public interface MailboxProviderKeeper {
+  Mailbox assignMailbox(final String name, final int hashCode);
+  void close();
+  String findDefault();
+  void keep(final String name, boolean isDefault, final MailboxProvider mailboxProvider);
+  boolean isValidMailboxName(final String candidateMailboxName);
 }

--- a/src/main/java/io/vlingo/actors/Registrar.java
+++ b/src/main/java/io/vlingo/actors/Registrar.java
@@ -14,6 +14,7 @@ public interface Registrar {
 
   void registerCommonSupervisor(final String stageName, final String name, final Class<?> supervisedProtocol, final Class<? extends Actor> supervisorClass);
   void registerDefaultSupervisor(final String stageName, final String name, final Class<? extends Actor> supervisorClass);
+  void registerMailboxProviderKeeper(final MailboxProviderKeeper keeper);
 
   World world();
 }

--- a/src/main/java/io/vlingo/actors/World.java
+++ b/src/main/java/io/vlingo/actors/World.java
@@ -7,6 +7,8 @@
 
 package io.vlingo.actors;
 
+import io.vlingo.actors.plugin.mailbox.DefaultMailboxProviderKeeper;
+
 import java.util.HashMap;
 import java.util.Map;
 
@@ -25,10 +27,10 @@ public final class World implements Registrar {
   private final CompletesEventuallyProviderKeeper completesProviderKeeper;
   private final Configuration configuration;
   private final LoggerProviderKeeper loggerProviderKeeper;
-  private final MailboxProviderKeeper mailboxProviderKeeper;
+  private MailboxProviderKeeper mailboxProviderKeeper;
   private final String name;
-  private final Map<String,Stage> stages;
-  
+  private final Map<String, Stage> stages;
+
   private DeadLetters deadLetters;
   private Logger defaultLogger;
   private Actor defaultParent;
@@ -92,14 +94,14 @@ public final class World implements Registrar {
     if (this.defaultLogger != null) {
       return defaultLogger;
     }
-    
+
     if (loggerProviderKeeper != null) {
       final LoggerProvider maybeLoggerProvider = loggerProviderKeeper.findDefault();
       this.defaultLogger = maybeLoggerProvider != null ?
-              maybeLoggerProvider.logger() :
-              LoggerProvider.noOpLoggerProvider().logger();
+          maybeLoggerProvider.logger() :
+          LoggerProvider.noOpLoggerProvider().logger();
     }
-    
+
     if (this.defaultLogger == null) {
       this.defaultLogger = LoggerProvider.standardLoggerProvider(this, "vlingo").logger();
     }
@@ -173,13 +175,13 @@ public final class World implements Registrar {
 
   public synchronized Stage stageNamed(final String name) {
     Stage stage = stages.get(name);
-    
+
     if (stage == null) {
       stage = new Stage(this, name);
       if (!name.equals(DEFAULT_STAGE)) stage.startDirectoryScanner();
       stages.put(name, stage);
     }
-    
+
     return stage;
   }
 
@@ -192,7 +194,7 @@ public final class World implements Registrar {
       for (final Stage stage : stages.values()) {
         stage.stop();
       }
-      
+
       loggerProviderKeeper.close();
       mailboxProviderKeeper.close();
       completesProviderKeeper.close();
@@ -226,7 +228,7 @@ public final class World implements Registrar {
     if (defaultParent != null && this.defaultParent != null) {
       throw new IllegalStateException("Default parent already exists.");
     }
-    
+
     this.defaultParent = defaultParent;
   }
 
@@ -248,7 +250,7 @@ public final class World implements Registrar {
       privateRoot.stop();
       throw new IllegalStateException("Private root already exists.");
     }
-    
+
     this.privateRoot = privateRoot;
   }
 
@@ -264,17 +266,23 @@ public final class World implements Registrar {
     this.publicRoot = publicRoot;
   }
 
+  @Override
+  public void registerMailboxProviderKeeper(final MailboxProviderKeeper keeper) {
+    this.mailboxProviderKeeper = keeper;
+  }
+
   private World(final String name, final Configuration configuration) {
     this.name = name;
     this.configuration = configuration;
     this.addressFactory = new AddressFactory();
     this.completesProviderKeeper = new CompletesEventuallyProviderKeeper();
     this.loggerProviderKeeper = new LoggerProviderKeeper();
-    this.mailboxProviderKeeper = new MailboxProviderKeeper();
+    this.mailboxProviderKeeper = new DefaultMailboxProviderKeeper();
     this.stages = new HashMap<>();
 
     final Stage defaultStage = stageNamed(DEFAULT_STAGE);
 
+//    configuration.startPlugins(this, 0);
     configuration.startPlugins(this, 1);
 
     startRootFor(defaultStage, defaultLogger());
@@ -286,12 +294,12 @@ public final class World implements Registrar {
 
   private void startRootFor(final Stage stage, final Logger logger) {
     stage.actorProtocolFor(
-            Definition.has(PrivateRootActor.class, Definition.NoParameters, PRIVATE_ROOT_NAME),
-            Stoppable.class,
-            null,
-            addressFactory.from(PRIVATE_ROOT_ID, PRIVATE_ROOT_NAME),
-            null,
-            null,
-            logger);
+        Definition.has(PrivateRootActor.class, Definition.NoParameters, PRIVATE_ROOT_NAME),
+        Stoppable.class,
+        null,
+        addressFactory.from(PRIVATE_ROOT_ID, PRIVATE_ROOT_NAME),
+        null,
+        null,
+        logger);
   }
 }

--- a/src/main/java/io/vlingo/actors/World.java
+++ b/src/main/java/io/vlingo/actors/World.java
@@ -268,6 +268,10 @@ public final class World implements Registrar {
 
   @Override
   public void registerMailboxProviderKeeper(final MailboxProviderKeeper keeper) {
+    if (this.mailboxProviderKeeper != null) {
+      this.mailboxProviderKeeper.close();
+    }
+
     this.mailboxProviderKeeper = keeper;
   }
 
@@ -282,7 +286,7 @@ public final class World implements Registrar {
 
     final Stage defaultStage = stageNamed(DEFAULT_STAGE);
 
-//    configuration.startPlugins(this, 0);
+    configuration.startPlugins(this, 0);
     configuration.startPlugins(this, 1);
 
     startRootFor(defaultStage, defaultLogger());

--- a/src/main/java/io/vlingo/actors/World.java
+++ b/src/main/java/io/vlingo/actors/World.java
@@ -27,7 +27,6 @@ public final class World implements Registrar {
   private final CompletesEventuallyProviderKeeper completesProviderKeeper;
   private final Configuration configuration;
   private final LoggerProviderKeeper loggerProviderKeeper;
-  private MailboxProviderKeeper mailboxProviderKeeper;
   private final String name;
   private final Map<String, Stage> stages;
 
@@ -37,6 +36,7 @@ public final class World implements Registrar {
   private Supervisor defaultSupervisor;
   private Stoppable privateRoot;
   private Stoppable publicRoot;
+  private MailboxProviderKeeper mailboxProviderKeeper;
 
   public static synchronized World start(final String name) {
     return start(name, io.vlingo.actors.Properties.properties);

--- a/src/main/java/io/vlingo/actors/plugin/logging/jdk/JDKLoggerActor.java
+++ b/src/main/java/io/vlingo/actors/plugin/logging/jdk/JDKLoggerActor.java
@@ -7,6 +7,10 @@ public class JDKLoggerActor extends Actor implements Logger {
   private final JDKLogger logger;
   
   public JDKLoggerActor(final JDKLogger logger) {
+    if (logger == null) {
+      throw new NullPointerException("JDKLogger can not be null");
+    }
+
     this.logger = logger;
   }
 

--- a/src/main/java/io/vlingo/actors/plugin/logging/jdk/JDKLoggerPlugin.java
+++ b/src/main/java/io/vlingo/actors/plugin/logging/jdk/JDKLoggerPlugin.java
@@ -55,8 +55,7 @@ public class JDKLoggerPlugin extends AbstractPlugin implements Plugin, LoggerPro
 
   @Override
   public int pass() {
-    pass = pass == 0 ? 1 : 2;
-    return pass;
+    return ++pass;
   }
 
   @Override

--- a/src/main/java/io/vlingo/actors/plugin/mailbox/DefaultMailboxProviderKeeper.java
+++ b/src/main/java/io/vlingo/actors/plugin/mailbox/DefaultMailboxProviderKeeper.java
@@ -55,9 +55,7 @@ public final class DefaultMailboxProviderKeeper implements MailboxProviderKeeper
   }
 
   public boolean isValidMailboxName(final String candidateMailboxName) {
-    final MailboxProviderInfo info = mailboxProviderInfos.get(candidateMailboxName);
-
-    return info != null;
+    return mailboxProviderInfos.containsKey(candidateMailboxName);
   }
 
   private static final class MailboxProviderInfo {

--- a/src/main/java/io/vlingo/actors/plugin/mailbox/DefaultMailboxProviderKeeper.java
+++ b/src/main/java/io/vlingo/actors/plugin/mailbox/DefaultMailboxProviderKeeper.java
@@ -15,7 +15,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public final class DefaultMailboxProviderKeeper implements MailboxProviderKeeper {
-  private final Map<String,MailboxProviderInfo> mailboxProviderInfos;
+  private final Map<String, MailboxProviderInfo> mailboxProviderInfos;
 
   public DefaultMailboxProviderKeeper() {
     this.mailboxProviderInfos = new HashMap<>();

--- a/src/main/java/io/vlingo/actors/plugin/mailbox/DefaultMailboxProviderKeeper.java
+++ b/src/main/java/io/vlingo/actors/plugin/mailbox/DefaultMailboxProviderKeeper.java
@@ -1,0 +1,89 @@
+// Copyright © 2012-2018 Vaughn Vernon. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0. If a copy of the MPL
+// was not distributed with this file, You can obtain
+// one at https://mozilla.org/MPL/2.0/.
+
+package io.vlingo.actors.plugin.mailbox;
+
+import io.vlingo.actors.Mailbox;
+import io.vlingo.actors.MailboxProvider;
+import io.vlingo.actors.MailboxProviderKeeper;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public final class DefaultMailboxProviderKeeper implements MailboxProviderKeeper {
+  private final Map<String,MailboxProviderInfo> mailboxProviderInfos;
+
+  public DefaultMailboxProviderKeeper() {
+    this.mailboxProviderInfos = new HashMap<>();
+  }
+
+  public Mailbox assignMailbox(final String name, final int hashCode) {
+    MailboxProviderInfo info = mailboxProviderInfos.get(name);
+
+    if (info == null) {
+      throw new IllegalStateException("No registered MailboxProvider named " + name);
+    }
+
+    return info.mailboxProvider.provideMailboxFor(hashCode);
+  }
+
+  public void close() {
+    for (final MailboxProviderInfo info : mailboxProviderInfos.values()) {
+      info.mailboxProvider.close();
+    }
+  }
+
+  public String findDefault() {
+    for (final MailboxProviderInfo info : mailboxProviderInfos.values()) {
+      if (info.isDefault) {
+        return info.name;
+      }
+    }
+
+    throw new IllegalStateException("No registered default MailboxProvider.");
+  }
+
+  public void keep(final String name, boolean isDefault, final MailboxProvider mailboxProvider) {
+    if (mailboxProviderInfos.isEmpty()) {
+      isDefault = true;
+    }
+    
+    if (isDefault) {
+      undefaultCurrentDefault();
+    }
+
+    mailboxProviderInfos.put(name, new MailboxProviderInfo(name, mailboxProvider, isDefault));
+  }
+
+  public boolean isValidMailboxName(final String candidateMailboxName) {
+    final MailboxProviderInfo info = mailboxProviderInfos.get(candidateMailboxName);
+
+    return info != null;
+  }
+
+    private void undefaultCurrentDefault() {
+        for (final String key : mailboxProviderInfos.keySet()) {
+            final MailboxProviderInfo info = mailboxProviderInfos.get(key);
+
+            if (info.isDefault) {
+                mailboxProviderInfos.put(key, new MailboxProviderInfo(info.name, info.mailboxProvider, false));
+            }
+        }
+    }
+
+  private static final class MailboxProviderInfo {
+    final boolean isDefault;
+    final MailboxProvider mailboxProvider;
+    final String name;
+
+    MailboxProviderInfo(final String name, final MailboxProvider mailboxProvider, final boolean isDefault) {
+      this.name = name;
+      this.mailboxProvider = mailboxProvider;
+      this.isDefault = isDefault;
+    }
+  }
+}

--- a/src/main/java/io/vlingo/actors/plugin/mailbox/DefaultMailboxProviderKeeperPlugin.java
+++ b/src/main/java/io/vlingo/actors/plugin/mailbox/DefaultMailboxProviderKeeperPlugin.java
@@ -21,9 +21,12 @@ public class DefaultMailboxProviderKeeperPlugin implements Plugin {
     this.configuration = configuration;
   }
 
+  public DefaultMailboxProviderKeeperPlugin() {
+    this(new DefaultMailboxProviderKeeper(), new DefaultMailboxProviderKeeperPluginConfiguration());
+  }
+
   @Override
   public void close() {
-
   }
 
   @Override

--- a/src/main/java/io/vlingo/actors/plugin/mailbox/DefaultMailboxProviderKeeperPlugin.java
+++ b/src/main/java/io/vlingo/actors/plugin/mailbox/DefaultMailboxProviderKeeperPlugin.java
@@ -14,9 +14,11 @@ import io.vlingo.actors.plugin.PluginConfiguration;
 
 public class DefaultMailboxProviderKeeperPlugin implements Plugin {
   private final MailboxProviderKeeper keeper;
+  private final DefaultMailboxProviderKeeperPluginConfiguration configuration;
 
-  public DefaultMailboxProviderKeeperPlugin(final MailboxProviderKeeper keeper) {
+  public DefaultMailboxProviderKeeperPlugin(final MailboxProviderKeeper keeper, final DefaultMailboxProviderKeeperPluginConfiguration configuration) {
     this.keeper = keeper;
+    this.configuration = configuration;
   }
 
   @Override
@@ -26,12 +28,12 @@ public class DefaultMailboxProviderKeeperPlugin implements Plugin {
 
   @Override
   public PluginConfiguration configuration() {
-    return new DefaultMailboxProviderKeeperPluginConfiguration();
+    return configuration;
   }
 
   @Override
   public String name() {
-    return "default-mailbox-provider-keeper";
+    return configuration.name();
   }
 
   @Override

--- a/src/main/java/io/vlingo/actors/plugin/mailbox/DefaultMailboxProviderKeeperPlugin.java
+++ b/src/main/java/io/vlingo/actors/plugin/mailbox/DefaultMailboxProviderKeeperPlugin.java
@@ -1,0 +1,46 @@
+// Copyright © 2012-2018 Vaughn Vernon. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0. If a copy of the MPL
+// was not distributed with this file, You can obtain
+// one at https://mozilla.org/MPL/2.0/.
+
+package io.vlingo.actors.plugin.mailbox;
+
+import io.vlingo.actors.MailboxProviderKeeper;
+import io.vlingo.actors.Registrar;
+import io.vlingo.actors.plugin.Plugin;
+import io.vlingo.actors.plugin.PluginConfiguration;
+
+public class DefaultMailboxProviderKeeperPlugin implements Plugin {
+  private final MailboxProviderKeeper keeper;
+
+  public DefaultMailboxProviderKeeperPlugin(final MailboxProviderKeeper keeper) {
+    this.keeper = keeper;
+  }
+
+  @Override
+  public void close() {
+
+  }
+
+  @Override
+  public PluginConfiguration configuration() {
+    return new DefaultMailboxProviderKeeperPluginConfiguration();
+  }
+
+  @Override
+  public String name() {
+    return "default-mailbox-provider-keeper";
+  }
+
+  @Override
+  public int pass() {
+    return 0;
+  }
+
+  @Override
+  public void start(final Registrar registrar) {
+    registrar.registerMailboxProviderKeeper(keeper);
+  }
+}

--- a/src/main/java/io/vlingo/actors/plugin/mailbox/DefaultMailboxProviderKeeperPluginConfiguration.java
+++ b/src/main/java/io/vlingo/actors/plugin/mailbox/DefaultMailboxProviderKeeperPluginConfiguration.java
@@ -1,0 +1,29 @@
+// Copyright © 2012-2018 Vaughn Vernon. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0. If a copy of the MPL
+// was not distributed with this file, You can obtain
+// one at https://mozilla.org/MPL/2.0/.
+
+package io.vlingo.actors.plugin.mailbox;
+
+import io.vlingo.actors.Configuration;
+import io.vlingo.actors.plugin.PluginConfiguration;
+import io.vlingo.actors.plugin.PluginProperties;
+
+public class DefaultMailboxProviderKeeperPluginConfiguration implements PluginConfiguration {
+  @Override
+  public void build(final Configuration configuration) {
+
+  }
+
+  @Override
+  public void buildWith(final Configuration configuration, final PluginProperties properties) {
+
+  }
+
+  @Override
+  public String name() {
+    return "mailbox-provider-keeper-plugin-configuration";
+  }
+}

--- a/src/main/java/io/vlingo/actors/plugin/mailbox/DefaultMailboxProviderKeeperPluginConfiguration.java
+++ b/src/main/java/io/vlingo/actors/plugin/mailbox/DefaultMailboxProviderKeeperPluginConfiguration.java
@@ -24,6 +24,6 @@ public class DefaultMailboxProviderKeeperPluginConfiguration implements PluginCo
 
   @Override
   public String name() {
-    return "mailbox-provider-keeper-plugin-configuration";
+    return "defaultMailboxProviderKeeper";
   }
 }

--- a/src/test/java/io/vlingo/actors/ActorStopTest.java
+++ b/src/test/java/io/vlingo/actors/ActorStopTest.java
@@ -17,7 +17,7 @@ import org.junit.Test;
 import io.vlingo.actors.testkit.TestUntil;
 
 public class ActorStopTest extends ActorsTest {
-  @Test
+  @Test(timeout = 1000)
   public void testStopActors() throws Exception {
     System.out.println("Test: testStopActors");
 
@@ -61,7 +61,7 @@ public class ActorStopTest extends ActorsTest {
     assertEquals(0, testResults.terminatingStopCount.get());
   }
 
-  @Test
+  @Test(timeout = 1000)
   public void testWorldTerminateToStopAllActors() throws Exception {
     final TestResults testSpecs = new TestResults();
     

--- a/src/test/java/io/vlingo/actors/plugin/completes/MockRegistrar.java
+++ b/src/test/java/io/vlingo/actors/plugin/completes/MockRegistrar.java
@@ -27,16 +27,15 @@ public class MockRegistrar implements Registrar {
   }
 
   @Override
-  public void registerCommonSupervisor(String stageName, String name, Class<?> supervisedProtocol, Class<? extends Actor> supervisorClass) {
+  public void registerCommonSupervisor(String stageName, String name, final Class<?> supervisedProtocol, final Class<? extends Actor> supervisorClass) {
   }
 
   @Override
-  public void registerDefaultSupervisor(String stageName, String name, Class<? extends Actor> supervisorClass) {
+  public void registerDefaultSupervisor(String stageName, String name, final Class<? extends Actor> supervisorClass) {
   }
 
   @Override
   public void registerMailboxProviderKeeper(final MailboxProviderKeeper keeper) {
-
   }
 
   @Override

--- a/src/test/java/io/vlingo/actors/plugin/completes/MockRegistrar.java
+++ b/src/test/java/io/vlingo/actors/plugin/completes/MockRegistrar.java
@@ -7,12 +7,7 @@
 
 package io.vlingo.actors.plugin.completes;
 
-import io.vlingo.actors.Actor;
-import io.vlingo.actors.CompletesEventuallyProvider;
-import io.vlingo.actors.LoggerProvider;
-import io.vlingo.actors.MailboxProvider;
-import io.vlingo.actors.Registrar;
-import io.vlingo.actors.World;
+import io.vlingo.actors.*;
 
 public class MockRegistrar implements Registrar {
   public int registerCount;
@@ -37,6 +32,11 @@ public class MockRegistrar implements Registrar {
 
   @Override
   public void registerDefaultSupervisor(String stageName, String name, Class<? extends Actor> supervisorClass) {
+  }
+
+  @Override
+  public void registerMailboxProviderKeeper(final MailboxProviderKeeper keeper) {
+
   }
 
   @Override

--- a/src/test/java/io/vlingo/actors/plugin/logger/JDKLoggerTest.java
+++ b/src/test/java/io/vlingo/actors/plugin/logger/JDKLoggerTest.java
@@ -13,6 +13,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.Properties;
 
+import io.vlingo.actors.plugin.completes.MockRegistrar;
 import org.junit.After;
 import org.junit.Test;
 
@@ -32,32 +33,10 @@ public class JDKLoggerTest {
   private boolean registered;
   private World world;
   
-  final Registrar registrar = new Registrar() {
-    @Override
-    public void register(String name, CompletesEventuallyProvider completesEventuallyProvider) {
-      
-    }
-
-    @Override
-    public void register(String name, boolean isDefault, MailboxProvider mailboxProvider) {
-    }
-
+  final Registrar registrar = new MockRegistrar() {
     @Override
     public void register(String name, boolean isDefault, LoggerProvider loggerProvider) {
       registered = true;
-    }
-
-    @Override
-    public void registerCommonSupervisor(String stageName, String name, Class<?> supervisedProtocol, Class<? extends Actor> supervisorClass) {
-    }
-
-    @Override
-    public void registerDefaultSupervisor(String stageName, String name, Class<? extends Actor> supervisorClass) {
-    }
-
-    @Override
-    public World world() {
-      return null;
     }
   };
 

--- a/src/test/java/io/vlingo/actors/plugin/mailbox/DefaultMailboxProviderKeeperPluginTest.java
+++ b/src/test/java/io/vlingo/actors/plugin/mailbox/DefaultMailboxProviderKeeperPluginTest.java
@@ -7,33 +7,39 @@
 
 package io.vlingo.actors.plugin.mailbox;
 
+import io.vlingo.actors.ActorsTest;
 import io.vlingo.actors.MailboxProviderKeeper;
 import io.vlingo.actors.Registrar;
 import io.vlingo.actors.plugin.Plugin;
 import io.vlingo.actors.plugin.PluginConfiguration;
+import io.vlingo.actors.plugin.PluginProperties;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import java.util.Properties;
+
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.verify;
 
-public class DefaultMailboxProviderKeeperPluginTest {
+public class DefaultMailboxProviderKeeperPluginTest extends ActorsTest {
   private Plugin plugin;
   private Registrar registrar;
   private MailboxProviderKeeper keeper;
 
   @Before
-  public void setUp() {
+  public void setUp() throws Exception {
+    super.setUp();
+
     registrar = Mockito.mock(Registrar.class);
     keeper = Mockito.mock(MailboxProviderKeeper.class);
 
-    plugin = new DefaultMailboxProviderKeeperPlugin(keeper);
+    plugin = new DefaultMailboxProviderKeeperPlugin(keeper, new DefaultMailboxProviderKeeperPluginConfiguration());
   }
 
   @Test
   public void testThatItUsesTheCorrectName() {
-    assertEquals("default-mailbox-provider-keeper", plugin.name());
+    assertEquals("defaultMailboxProviderKeeper", plugin.name());
   }
 
   @Test
@@ -53,5 +59,20 @@ public class DefaultMailboxProviderKeeperPluginTest {
     PluginConfiguration configuration = plugin.configuration();
 
     assertEquals(configuration.getClass(), DefaultMailboxProviderKeeperPluginConfiguration.class);
+  }
+
+  @Test
+  public void testThatRegistersTheProvidedKeeperInARealWorld() {
+    final Properties properties = new Properties() {{
+      setProperty("plugin.name.defaultMailboxProviderKeeper", "true");
+    }};
+
+    final PluginProperties pluginProperties = new PluginProperties("defaultMailboxProviderKeeper", properties);
+    plugin.configuration().buildWith(world.configuration(), pluginProperties);
+
+    plugin.start(world);
+    world.terminate();
+
+    verify(keeper).close();
   }
 }

--- a/src/test/java/io/vlingo/actors/plugin/mailbox/DefaultMailboxProviderKeeperPluginTest.java
+++ b/src/test/java/io/vlingo/actors/plugin/mailbox/DefaultMailboxProviderKeeperPluginTest.java
@@ -1,0 +1,57 @@
+// Copyright © 2012-2018 Vaughn Vernon. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0. If a copy of the MPL
+// was not distributed with this file, You can obtain
+// one at https://mozilla.org/MPL/2.0/.
+
+package io.vlingo.actors.plugin.mailbox;
+
+import io.vlingo.actors.MailboxProviderKeeper;
+import io.vlingo.actors.Registrar;
+import io.vlingo.actors.plugin.Plugin;
+import io.vlingo.actors.plugin.PluginConfiguration;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.verify;
+
+public class DefaultMailboxProviderKeeperPluginTest {
+  private Plugin plugin;
+  private Registrar registrar;
+  private MailboxProviderKeeper keeper;
+
+  @Before
+  public void setUp() {
+    registrar = Mockito.mock(Registrar.class);
+    keeper = Mockito.mock(MailboxProviderKeeper.class);
+
+    plugin = new DefaultMailboxProviderKeeperPlugin(keeper);
+  }
+
+  @Test
+  public void testThatItUsesTheCorrectName() {
+    assertEquals("default-mailbox-provider-keeper", plugin.name());
+  }
+
+  @Test
+  public void testThatItsTheFirstPass() {
+    assertEquals(0, plugin.pass());
+  }
+
+  @Test
+  public void testThatStartRegistersTheProvidedKeeper() {
+    plugin.start(registrar);
+
+    verify(registrar).registerMailboxProviderKeeper(keeper);
+  }
+
+  @Test
+  public void testThatReturnsTheCorrectConfiguration() {
+    PluginConfiguration configuration = plugin.configuration();
+
+    assertEquals(configuration.getClass(), DefaultMailboxProviderKeeperPluginConfiguration.class);
+  }
+}

--- a/src/test/java/io/vlingo/actors/plugin/mailbox/DefaultMailboxProviderKeeperTest.java
+++ b/src/test/java/io/vlingo/actors/plugin/mailbox/DefaultMailboxProviderKeeperTest.java
@@ -1,0 +1,68 @@
+package io.vlingo.actors.plugin.mailbox;
+
+import io.vlingo.actors.MailboxProvider;
+import io.vlingo.actors.MailboxProviderKeeper;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.UUID;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+public class DefaultMailboxProviderKeeperTest {
+  private static String MAILBOX_NAME = "Mailbox-" + UUID.randomUUID().toString();
+  private static int SOME_HASHCODE = UUID.randomUUID().hashCode();
+
+  private MailboxProvider mailboxProvider;
+  private MailboxProviderKeeper keeper;
+
+  @Before
+  public void setUp() {
+    mailboxProvider = mock(MailboxProvider.class);
+    keeper = new DefaultMailboxProviderKeeper();
+
+    keeper.keep(MAILBOX_NAME, false, mailboxProvider);
+  }
+
+  @Test
+  public void testThatAssignsAMailboxFromTheSpecifiedProvider() {
+    keeper.assignMailbox(MAILBOX_NAME, SOME_HASHCODE);
+
+    verify(mailboxProvider).provideMailboxFor(SOME_HASHCODE);
+  }
+
+  @Test
+  public void testThatKeepingADefaultMailboxOverridesTheCurrentDefault() {
+    MailboxProvider newDefault = mock(MailboxProvider.class);
+    String name = "NewDefault-" + UUID.randomUUID().toString();
+
+    keeper.keep(name, true, newDefault);
+    assertEquals(name, keeper.findDefault());
+  }
+
+  @Test
+  public void testThatClosesAllProviders() {
+    keeper.close();
+    verify(mailboxProvider).close();
+  }
+
+  @Test
+  public void testThatIsValidMailboxNameChecksForMailboxExistance() {
+    assertTrue(keeper.isValidMailboxName(MAILBOX_NAME));
+    assertFalse(keeper.isValidMailboxName(MAILBOX_NAME + "_DoesNotExist"));
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testThatAssigningAnUnknownMailboxFailsGracefully() {
+    keeper.assignMailbox(MAILBOX_NAME + "_DoesNotExist", SOME_HASHCODE);
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testThatNoDefaultProviderWillFailGracefully() {
+    new DefaultMailboxProviderKeeper().findDefault();
+  }
+}


### PR DESCRIPTION
We found that would be really useful to be able to change ProviderKeepers with plugins. For example, a TelemetryMailboxProviderKeeper that wraps all MailboxProviders with telemetry.

This PR attempts to refactor and add this support.