### PR TITLE
Add support for dynamic dependencies

### DIFF
--- a/src/main/java/io/vlingo/actors/World.java
+++ b/src/main/java/io/vlingo/actors/World.java
@@ -29,6 +29,7 @@ public final class World implements Registrar {
   private final Configuration configuration;
   private final String name;
   private final Map<String, Stage> stages;
+  private final Map<String, Object> dynamicDependencies;
 
   private CompletesEventuallyProviderKeeper completesProviderKeeper;
   private DeadLetters deadLetters;
@@ -300,6 +301,7 @@ public final class World implements Registrar {
     this.loggerProviderKeeper = new DefaultLoggerProviderKeeper();
     this.mailboxProviderKeeper = new DefaultMailboxProviderKeeper();
     this.stages = new HashMap<>();
+    this.dynamicDependencies = new HashMap<>();
 
     final Stage defaultStage = stageNamed(DEFAULT_STAGE);
 
@@ -322,5 +324,13 @@ public final class World implements Registrar {
         null,
         null,
         logger);
+  }
+
+  public void registerDynamic(final String name, final Object dep) {
+    this.dynamicDependencies.put(name, dep);
+  }
+
+  public <DEPENDENCY> DEPENDENCY resolveDynamic(final String name, final Class<DEPENDENCY> anyDependencyClass) {
+    return anyDependencyClass.cast(this.dynamicDependencies.get(name));
   }
 }

--- a/src/main/java/io/vlingo/actors/World.java
+++ b/src/main/java/io/vlingo/actors/World.java
@@ -196,6 +196,15 @@ public final class World implements Registrar {
     this.mailboxProviderKeeper = keeper;
   }
 
+
+  public void registerDynamic(final String name, final Object dep) {
+    this.dynamicDependencies.put(name, dep);
+  }
+
+  public <DEPENDENCY> DEPENDENCY resolveDynamic(final String name, final Class<DEPENDENCY> anyDependencyClass) {
+    return anyDependencyClass.cast(this.dynamicDependencies.get(name));
+  }
+
   public Stage stage() {
     return stageNamed(DEFAULT_STAGE);
   }
@@ -326,11 +335,4 @@ public final class World implements Registrar {
         logger);
   }
 
-  public void registerDynamic(final String name, final Object dep) {
-    this.dynamicDependencies.put(name, dep);
-  }
-
-  public <DEPENDENCY> DEPENDENCY resolveDynamic(final String name, final Class<DEPENDENCY> anyDependencyClass) {
-    return anyDependencyClass.cast(this.dynamicDependencies.get(name));
-  }
 }

--- a/src/test/java/io/vlingo/actors/WorldTest.java
+++ b/src/test/java/io/vlingo/actors/WorldTest.java
@@ -12,12 +12,14 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.junit.After;
 import org.junit.Test;
 
 import io.vlingo.actors.testkit.TestUntil;
+import org.mockito.Mockito;
 
 public class WorldTest extends ActorsTest {
   @Test
@@ -51,6 +53,17 @@ public class WorldTest extends ActorsTest {
     assertTrue(testResults.invoked.get());
   }
 
+  @Test
+  public void testThatARegisteredDependencyCanBeResolved() throws Exception {
+    String name = UUID.randomUUID().toString();
+
+    AnyDependency dep = Mockito.mock(AnyDependency.class);
+    world.registerDynamic(name, dep);
+
+    AnyDependency result = world.resolveDynamic(name, AnyDependency.class);
+    assertEquals(dep, result);
+  }
+
   @After
   @Override
   public void tearDown() throws Exception {
@@ -82,4 +95,6 @@ public class WorldTest extends ActorsTest {
     public AtomicBoolean invoked = new AtomicBoolean(false);
     public TestUntil untilSimple = TestUntil.happenings(0);
   }
+
+  public interface AnyDependency {}
 }


### PR DESCRIPTION
Add support for dynamic dependencies (by name) to World. The idea is to have services/dependencies that are not declared on vlingo-actors but in other plugins, like Telemetry, into World, so Actors can access them.