### PR TITLE
Feature/completes sync allow different types

### DIFF
--- a/src/main/java/io/vlingo/actors/BasicCompletes.java
+++ b/src/main/java/io/vlingo/actors/BasicCompletes.java
@@ -51,16 +51,7 @@ public class BasicCompletes<T> implements Completes<T> {
   @Override
   @SuppressWarnings("unchecked")
   public <O> Completes<O> andThen(final long timeout, final T failedOutcomeValue, final Function<T,O> function) {
-    final BasicCompletes<O> nestedCompletes = new BasicCompletes<>(state.scheduler());
-    nestedCompletes.state.failedValue(failedOutcomeValue);
-    nestedCompletes.state.failureAction((Action<O>) state.failureActionFunction());
-    state.action((Action<T>) Action.with(function, nestedCompletes));
-    if (state.isCompleted()) {
-      state.completeActions();
-    } else {
-      state.startTimer(timeout);
-    }
-    return nestedCompletes;
+    return (Completes<O>) andThenInto(timeout, failedOutcomeValue, function);
   }
 
   @Override

--- a/src/main/java/io/vlingo/actors/BasicCompletes.java
+++ b/src/main/java/io/vlingo/actors/BasicCompletes.java
@@ -49,29 +49,23 @@ public class BasicCompletes<T> implements Completes<T> {
   }
 
   @Override
-  public Completes<T> andThen(final long timeout, final T failedOutcomeValue, final Function<T,T> function) {
-    state.failedValue(failedOutcomeValue);
-    state.action(Action.with(function));
-    if (state.isCompleted()) {
-      state.completeActions();
-    } else {
-      state.startTimer(timeout);
-    }
-    return this;
+  @SuppressWarnings("unchecked")
+  public <O> Completes<O> andThen(final long timeout, final T failedOutcomeValue, final Function<T,O> function) {
+    return Completes.withSuccess(andThenInto(timeout,failedOutcomeValue, function));
   }
 
   @Override
-  public Completes<T> andThen(final T failedOutcomeValue, final Function<T,T> function) {
+  public <O> Completes<O> andThen(final T failedOutcomeValue, final Function<T,O> function) {
     return andThen(-1L, failedOutcomeValue, function);
   }
 
   @Override
-  public Completes<T> andThen(final long timeout, final Function<T,T> function) {
+  public <O> Completes<O> andThen(final long timeout, final Function<T,O> function) {
     return andThen(timeout, null, function);
   }
 
   @Override
-  public Completes<T> andThen(final Function<T,T> function) {
+  public <O> Completes<O> andThen(final Function<T,O> function) {
     return andThen(-1L, null, function);
   }
 

--- a/src/main/java/io/vlingo/actors/Completes.java
+++ b/src/main/java/io/vlingo/actors/Completes.java
@@ -43,10 +43,10 @@ public interface Completes<T> {
     return new RepeatableCompletes<T>((T) null, false);
   }
 
-  Completes<T> andThen(final long timeout, final T failedOutcomeValue, final Function<T,T> function);
-  Completes<T> andThen(final T failedOutcomeValue, final Function<T,T> function);
-  Completes<T> andThen(final long timeout, final Function<T,T> function);
-  Completes<T> andThen(final Function<T,T> function);
+  <O> Completes<O> andThen(final long timeout, final T failedOutcomeValue, final Function<T,O> function);
+  <O> Completes<O> andThen(final T failedOutcomeValue, final Function<T,O> function);
+  <O> Completes<O> andThen(final long timeout, final Function<T,O> function);
+  <O> Completes<O> andThen(final Function<T,O> function);
 
   Completes<T> andThenConsume(final long timeout, final T failedOutcomeValue, final Consumer<T> consumer);
   Completes<T> andThenConsume(final T failedOutcomeValue, final Consumer<T> consumer);

--- a/src/main/java/io/vlingo/actors/ResultCompletes.java
+++ b/src/main/java/io/vlingo/actors/ResultCompletes.java
@@ -16,22 +16,22 @@ public class ResultCompletes implements Completes<Object> {
   boolean outcomeSet = false;
 
   @Override
-  public Completes<Object> andThen(final Function<Object,Object> function) {
+  public <O> Completes<O> andThen(final Function<Object,O> function) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public Completes<Object> andThen(final long timeout, final Function<Object,Object> function) {
+  public <O> Completes<O> andThen(final long timeout, final Function<Object,O> function) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public Completes<Object> andThen(final Object failedOutcomeValue, final Function<Object,Object> function) {
+  public <O> Completes<O> andThen(final Object failedOutcomeValue, final Function<Object,O> function) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public Completes<Object> andThen(final long timeout, final Object failedOutcomeValue, final Function<Object,Object> function) {
+  public <O> Completes<O> andThen(final long timeout, final Object failedOutcomeValue, final Function<Object,O> function) {
     throw new UnsupportedOperationException();
   }
 


### PR DESCRIPTION
The motivation is be able to return different types using `andThen` instead of forcing the async method `andThen`.

Example:

```java
Completes<Response> queryUser(final String userId) {
        stage.world().defaultLogger().log("queryUser=" + userId);
        return stage.actorOf(addressFactory.from(userId), User.class)
                .andThenInto(User::toDTO)
                .andThenInto(dto -> Completes.withSuccess(Response.of(Ok, serialized(dto))))
                .otherwiseConsume(e -> Completes.withSuccess(Response.of(NotFound, serialized("not found"))))
                .recoverFrom(e -> Response.of(InternalServerError, serialized("uhh")));
    }
}

interface User {
   Completes<State> toDTO();
}
```

`toDTO` is forced to return `Completes<T>` to use `andThenInto`.