### PR TITLE
added jcenter repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,6 +77,12 @@
       </plugin>
     </plugins>
   </build>
+  <repositories>
+    <repository>
+      <id>jcenter</id>
+      <url>https://jcenter.bintray.com/</url>
+    </repository>
+  </repositories>
   <dependencies>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
Due to the Sonatype sync problem, we have the [PR](https://github.com/vlingo/vlingo-http/pull/20) blocked. See reason on [Travis Log](https://travis-ci.org/vlingo/vlingo-http/builds/476115914).

Using `jcenter` repository should solve the problem.