### PR TITLE
Rewrite some tests using AccessSafely.

### DIFF
--- a/src/test/java/io/vlingo/actors/ActorsTest.java
+++ b/src/test/java/io/vlingo/actors/ActorsTest.java
@@ -18,8 +18,6 @@ import io.vlingo.actors.testkit.TestWorld;
 public abstract class ActorsTest {
   protected World world;
   protected TestWorld testWorld;
-
-  public TestUntil until;
   
   protected ActorsTest() {
   }

--- a/src/test/java/io/vlingo/actors/CompletesActorProtocolTest.java
+++ b/src/test/java/io/vlingo/actors/CompletesActorProtocolTest.java
@@ -13,86 +13,81 @@ import static org.junit.Assert.assertNotEquals;
 import org.junit.Ignore;
 import org.junit.Test;
 
-import io.vlingo.actors.testkit.TestUntil;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import io.vlingo.common.Completes;
+import io.vlingo.actors.testkit.AccessSafely;
 
 public class CompletesActorProtocolTest extends ActorsTest {
   private static final String Hello = "Hello, Completes!";
   private static final String HelloNot = "Bye!";
   private static final String Prefix = "*** ";
-
-  private String greeting;
-  private int value;
-  private TestUntil untilHello = TestUntil.happenings(1);
-  private TestUntil untilOne = TestUntil.happenings(1);
-
+  
   @Test
   public void testReturnsCompletesForSideEffects() {
+    final TestResults testResults = TestResults.afterCompleting(2);
+
     final UsesCompletes uc = world.actorFor(UsesCompletes.class, UsesCompletesActor.class);
 
-    uc.getHello().andThenConsume((hello) -> setHello(hello.greeting));
-    untilHello.completes();
-    assertEquals(Hello, greeting);
-    uc.getOne().andThenConsume((value) -> setValue(value));
-    untilOne.completes();
-    assertEquals(1, value);
+    uc.getHello().andThenConsume((hello) -> testResults.setGreeting(hello.greeting));
+    uc.getOne().andThenConsume((value) -> testResults.setValue(value));
+
+    assertEquals(Hello, testResults.getGreeting());
+    assertEquals(1, testResults.getValue().intValue());
   }
 
   @Test
   public void testAfterAndThenCompletesForSideEffects() {
+    final TestResults greetingsTestResult = TestResults.afterCompleting(1);
+
     final UsesCompletes uc = world.actorFor(UsesCompletes.class, UsesCompletesActor.class);
     final Completes<Hello> helloCompletes = uc.getHello();
     helloCompletes.andThen((hello) -> new Hello(Prefix + hello.greeting))
-         .andThenConsume((hello) -> setHello(hello.greeting));
-    untilHello.completes();
+         .andThenConsume((hello) -> greetingsTestResult.setGreeting(hello.greeting));
+
+    assertNotEquals(Hello, greetingsTestResult.getGreeting());
     assertNotEquals(Hello, helloCompletes.outcome().greeting);
-    assertNotEquals(Hello, this.greeting);
+    assertEquals(Prefix + Hello, greetingsTestResult.getGreeting());
     assertEquals(Prefix + Hello, helloCompletes.outcome().greeting);
-    assertEquals(Prefix + Hello, this.greeting);
+
+    final TestResults valueTestResult = TestResults.afterCompleting(1);
 
     final Completes<Integer> one = uc.getOne();
-    one.andThen((value) -> value + 1).andThenConsume((value) -> setValue(value));
-    untilOne.completes();
+    one.andThen((value) -> value + 1).andThenConsume((value) -> valueTestResult.setValue(value));
+    
+    assertNotEquals(1, valueTestResult.getValue().intValue());
     assertNotEquals(new Integer(1), one.outcome());
-    assertNotEquals(1, this.value);
+    assertEquals(2, valueTestResult.getValue().intValue());
     assertEquals(new Integer(2), one.outcome());
-    assertEquals(2, this.value);
   }
 
   @Test
   @Ignore("Need explanation of why it should timeout")
-  public void testThatTimeOutOccursForSideEffects() throws Exception {
+  public void testThatTimeOutOccursForSideEffects() {
     final UsesCompletes uc = world.actorFor(UsesCompletes.class, UsesCompletesCausesTimeoutActor.class);
+    final TestResults greetingsTestResult = TestResults.afterCompleting(1);
 
     final Completes<Hello> helloCompletes =
             uc.getHello()
-              .andThenConsume(2, new Hello(HelloNot), (hello) -> setHello(hello.greeting))
-              .otherwise((failedHello) -> { setHello(failedHello.greeting); return failedHello; });
-    untilHello.completes();
-    assertNotEquals(Hello, greeting);
+              .andThenConsume(2, new Hello(HelloNot), (hello) -> greetingsTestResult.setGreeting(hello.greeting))
+              .otherwise((failedHello) -> { greetingsTestResult.setGreeting(failedHello.greeting); return failedHello; });
+
+    assertNotEquals(Hello, greetingsTestResult.getGreeting());
     assertEquals(HelloNot, helloCompletes.outcome().greeting);
+
+    final TestResults valueTestResult = TestResults.afterCompleting(1);
 
     final Completes<Integer> oneCompletes =
             uc.getOne()
-              .andThenConsume(2, 0, (Integer value) -> setValue(value))
-              .otherwise((Integer value) -> { untilOne.happened(); return 0; });
+              .andThenConsume(2, 0, (Integer value) -> valueTestResult.setValue(value))
+              .otherwise((Integer value) -> { valueTestResult.setValue(value); return 0; });
     try { Thread.sleep(100); } catch (Exception e) { }
     oneCompletes.with(1);
-    untilOne.completes();
-    assertNotEquals(1, value);
+    assertNotEquals(1, valueTestResult.getValue().intValue());
     assertEquals(new Integer(0), oneCompletes.outcome());
   }
-
-  private void setHello(final String hello) {
-    this.greeting = hello;
-    untilHello.happened();
-  }
-
-  private void setValue(final int value) {
-    this.value = value;
-    untilOne.happened();
-  }
-
+  
   public static class Hello {
     public final String greeting;
 
@@ -146,6 +141,42 @@ public class CompletesActorProtocolTest extends ActorsTest {
         // ignore
       }
       return completes().with(new Integer(1));
+    }
+  }
+
+
+  private static class TestResults{
+    private final AtomicReference<String> receivedGreeting = new AtomicReference<>(null);
+    private final AtomicInteger receivedValue = new AtomicInteger(0);
+    private final AccessSafely received;
+
+    private TestResults(AccessSafely received) {
+      this.received = received;
+    }
+
+    private static TestResults afterCompleting(final int times) {
+      final TestResults testResults = new TestResults(AccessSafely.afterCompleting(times));
+      testResults.received.writingWith("receivedGreeting", testResults.receivedGreeting::set);
+      testResults.received.readingWith("receivedGreeting", testResults.receivedGreeting::get);
+      testResults.received.writingWith("receivedValue", testResults.receivedValue::set);
+      testResults.received.readingWith("receivedValue", testResults.receivedValue::get);
+      return testResults;
+    }
+
+    private void setGreeting(String greeting){
+        this.received.writeUsing("receivedGreeting", greeting);
+    }
+
+    private void setValue(Integer value){
+        this.received.writeUsing("receivedValue", value);
+    }
+
+    private String getGreeting(){
+      return this.received.readFrom("receivedGreeting");
+    }
+
+    private Integer getValue(){
+      return this.received.readFrom("receivedValue");
     }
   }
 }

--- a/src/test/java/io/vlingo/actors/ContentBasedRouterTest.java
+++ b/src/test/java/io/vlingo/actors/ContentBasedRouterTest.java
@@ -11,49 +11,58 @@ import static org.junit.Assert.assertEquals;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 
+import io.vlingo.actors.testkit.AccessSafely;
 import org.junit.Test;
 
 import io.vlingo.actors.testkit.TestActor;
-import io.vlingo.actors.testkit.TestUntil;
+
 /**
  * ContentBasedRouterTest tests {@link ContentBasedRouter}.
  */
 public class ContentBasedRouterTest extends ActorsTest {
-  
+
   @Test
-  public void testThatItRoutes() throws Exception {
+  public void testThatItRoutes() {
     final int messagesToSend = 63;
-    final TestUntil until = TestUntil.happenings(messagesToSend);
-    
+
+    final TestResults testResults = new TestResults(messagesToSend);
+
     final ERPSystemCode[] erpsToTest = {ERPSystemCode.Alpha, ERPSystemCode.Beta, ERPSystemCode.Charlie};
-    
+
     final Protocols routerTestActorProtocols = world.actorFor(
             new Class[] {InvoiceSubmitter.class, InvoiceSubmitterSubscription.class},
-            Definition.has(InvoiceSubmissionRouter.class, Definition.parameters(until)));
+            Definition.has(InvoiceSubmissionRouter.class, Definition.parameters(testResults)));
+
     final Protocols.Two<InvoiceSubmitter, InvoiceSubmitterSubscription> routerProtocols = Protocols.two(routerTestActorProtocols);
     InvoiceSubmitter routerAsInvoiceSubmitter = routerProtocols._1;
     InvoiceSubmitterSubscription routerAsInvoiceSubmitterSubscription = routerProtocols._2;
-    
+
     final TestActor<InvoiceSubmitter> alphaSubmitterTestActor = testWorld.actorFor(
             InvoiceSubmitter.class,
-            Definition.has(ERPSpecificInvoiceSubmitter.class, Definition.parameters(ERPSystemCode.Alpha, until)));
+            Definition.has(ERPSpecificInvoiceSubmitter.class, Definition.parameters(ERPSystemCode.Alpha, testResults)));
     routerAsInvoiceSubmitterSubscription.subscribe(alphaSubmitterTestActor.actorAs());
-    
+
     final TestActor<InvoiceSubmitter> betaSubmitterTestActor = testWorld.actorFor(
             InvoiceSubmitter.class,
-            Definition.has(ERPSpecificInvoiceSubmitter.class, Definition.parameters(ERPSystemCode.Beta, until)));
+            Definition.has(ERPSpecificInvoiceSubmitter.class, Definition.parameters(ERPSystemCode.Beta, testResults)));
     routerAsInvoiceSubmitterSubscription.subscribe(betaSubmitterTestActor.actorAs());
-    
+
     final TestActor<InvoiceSubmitter> charlieSubmitterTestActor = testWorld.actorFor(
             InvoiceSubmitter.class,
-            Definition.has(ERPSpecificInvoiceSubmitter.class, Definition.parameters(ERPSystemCode.Charlie, until)));
+            Definition.has(ERPSpecificInvoiceSubmitter.class, Definition.parameters(ERPSystemCode.Charlie, testResults)));
     routerAsInvoiceSubmitterSubscription.subscribe(charlieSubmitterTestActor.actorAs());
-    
+
     final Random random = new Random(System.currentTimeMillis());
+
     int[] countByERP = new int[erpsToTest.length];
+
     Arrays.fill(countByERP, 0);
     for (int i = 0; i < messagesToSend; i++) {
       int erpIndex = random.nextInt(3);
@@ -62,54 +71,51 @@ public class ContentBasedRouterTest extends ActorsTest {
       routerAsInvoiceSubmitter.submitInvoice(invoice);
       countByERP[erpIndex] += 1;
     }
-    
-    until.completes();
-    
-    ERPSpecificInvoiceSubmitter alphaSubmitter = (ERPSpecificInvoiceSubmitter) alphaSubmitterTestActor.actorInside();
-    assertEquals("alpha invoice count", countByERP[Arrays.binarySearch(erpsToTest, ERPSystemCode.Alpha)], alphaSubmitter.submitted.size());
-    for (Invoice invoice : alphaSubmitter.submitted) {
-      assertEquals("invoice expected to be " + ERPSystemCode.Alpha, ERPSystemCode.Alpha, invoice.erp);
-    }
-    
-    ERPSpecificInvoiceSubmitter betaSubmitter = (ERPSpecificInvoiceSubmitter) betaSubmitterTestActor.actorInside();
-    assertEquals("beta invoice count", countByERP[Arrays.binarySearch(erpsToTest, ERPSystemCode.Beta)], betaSubmitter.submitted.size());
-    for (Invoice invoice : betaSubmitter.submitted) {
-      assertEquals("invoice expected to be " + ERPSystemCode.Beta, ERPSystemCode.Beta, invoice.erp);
-    }
-    
-    ERPSpecificInvoiceSubmitter charlieSubmitter = (ERPSpecificInvoiceSubmitter) charlieSubmitterTestActor.actorInside();
-    assertEquals("charlie invoice count", countByERP[Arrays.binarySearch(erpsToTest, ERPSystemCode.Charlie)], charlieSubmitter.submitted.size());
-    for (Invoice invoice : charlieSubmitter.submitted) {
-      assertEquals("invoice expected to be " + ERPSystemCode.Charlie, ERPSystemCode.Charlie, invoice.erp);
+
+    assertSubmittedInvoices(testResults, erpsToTest, countByERP, ERPSystemCode.Alpha);
+    assertSubmittedInvoices(testResults, erpsToTest, countByERP, ERPSystemCode.Beta);
+    assertSubmittedInvoices(testResults, erpsToTest, countByERP, ERPSystemCode.Charlie);
+}
+
+
+  private void assertSubmittedInvoices(TestResults testResults, ERPSystemCode[] erpsToTest, int[] countByERP, ERPSystemCode systemCode) {
+    final List<Invoice> alphaSubmittedInvoices = testResults.getSubmittedInvoices(systemCode);
+    assertEquals(systemCode + " invoice count", countByERP[Arrays.binarySearch(erpsToTest, systemCode)], alphaSubmittedInvoices.size());
+    for (Invoice invoice : alphaSubmittedInvoices) {
+      assertEquals("invoice expected to be " + systemCode, systemCode, invoice.erp);
     }
   }
-  
+
   public static interface InvoiceSubmitter {
     void submitInvoice(final Invoice invoice);
   }
-  
+
   public static interface InvoiceSubmitterSubscription {
     void subscribe(InvoiceSubmitter submitter);
     void unsubscribe(InvoiceSubmitter submitter);
   }
-  
+
   public static class InvoiceSubmissionRouter extends ContentBasedRouter<InvoiceSubmitter> implements InvoiceSubmitter, InvoiceSubmitterSubscription {
-    
-    public InvoiceSubmissionRouter(final TestUntil testUntil) {
+
+    public InvoiceSubmissionRouter(final TestResults testResults) {
       super(
-        new RouterSpecification<InvoiceSubmitter>(
+        new RouterSpecification<>(
           0,
-          Definition.has(ERPSpecificInvoiceSubmitter.class, Definition.parameters(ERPSystemCode.None, testUntil)),
+          Definition.has(ERPSpecificInvoiceSubmitter.class, Definition.parameters(ERPSystemCode.None, testResults)),
           InvoiceSubmitter.class)
         );
     }
-    
+
     /* @see io.vlingo.actors.Router#routingFor(java.lang.Object) */
     @Override
     protected <T1> Routing<InvoiceSubmitter> routingFor(final T1 routable1) {
-      return Routing.with(routees); //routees filter on erp
+      if (routable1 instanceof Invoice){
+        return Routing.with(routees); //routees filter on erp
+      } else {
+        return Routing.with(Collections.emptyList());
+      }
     }
-    
+
     /* @see io.vlingo.actors.ContentBasedRoutingStrategyTest.InvoiceSubmitterSubscription#subscribe(io.vlingo.actors.ContentBasedRoutingStrategyTest.InvoiceSubmitter) */
     @Override
     public void subscribe(InvoiceSubmitter submitter) {
@@ -128,43 +134,40 @@ public class ContentBasedRouterTest extends ActorsTest {
       dispatchCommand(InvoiceSubmitter::submitInvoice, invoice);
     }
   }
-  
+
   public static class ERPSpecificInvoiceSubmitter extends Actor implements InvoiceSubmitter {
-    
+
     private final ERPSystemCode erp;
-    private final TestUntil testUntil;
-    private final List<Invoice> submitted;
-    
-    public ERPSpecificInvoiceSubmitter(final ERPSystemCode erp, final TestUntil testUntil) {
+    private final TestResults testResults;
+
+    public ERPSpecificInvoiceSubmitter(final ERPSystemCode erp, final TestResults testResults) {
       super();
       this.erp = erp;
-      this.testUntil = testUntil;
-      this.submitted = new ArrayList<>();
+      this.testResults = testResults;
     }
 
     /* @see io.vlingo.actors.ContentBasedRoutingStrategyTest.InvoiceSubmitter#submitInvoice(io.vlingo.actors.ContentBasedRoutingStrategyTest.Invoice) */
     @Override
     public void submitInvoice(final Invoice invoice) {
-      if (erp.equals(invoice.erp)) {
-        submitted.add(invoice);
-        testUntil.happened();
+      if (this.erp.equals(invoice.erp)) {
+        testResults.invoiceSubmitted(invoice);
       }
     }
   }
-  
+
   public static enum ERPSystemCode {
     Alpha, Beta, Charlie, None
   }
-  
+
   public static class Invoice {
     private final ERPSystemCode erp;
     private final Integer invoiceId;
     private final BigDecimal amount;
-    
+
     public static Invoice with(final ERPSystemCode erp, final Integer invoiceId, final BigDecimal amount) {
       return new Invoice(erp, invoiceId, amount);
     }
-    
+
     Invoice(final ERPSystemCode erp, final Integer invoiceId, final BigDecimal amount) {
       this.erp = erp;
       this.invoiceId = invoiceId;
@@ -210,7 +213,7 @@ public class ContentBasedRouterTest extends ActorsTest {
         .toString();
     }
   }
-  
+
   private static BigDecimal randomMoney(final Random random) {
     int dollars = random.nextInt(10000);
     int cents = random.nextInt(100);
@@ -218,4 +221,24 @@ public class ContentBasedRouterTest extends ActorsTest {
     return new BigDecimal(amount);
   }
 
+  private static class TestResults {
+    private final AccessSafely submittedInvoices;
+
+    private TestResults(int times) {
+      final Map<ERPSystemCode, List<Invoice>> invoices = new ConcurrentHashMap<>(times);
+      this.submittedInvoices = AccessSafely.afterCompleting(times);
+      this.submittedInvoices.writingWith("submittedInvoices",
+              (ERPSystemCode key, Invoice value) -> invoices.computeIfAbsent(key, (code) ->  new ArrayList<>()).add(value));
+      this.submittedInvoices.readingWith("submittedInvoices",
+              (Function<ERPSystemCode, List<Invoice>>) invoices::get);
+    }
+
+    private void invoiceSubmitted(Invoice invoice){
+      this.submittedInvoices.writeUsing("submittedInvoices", invoice.erp, invoice);
+    }
+
+    private List<Invoice> getSubmittedInvoices(ERPSystemCode code){
+      return this.submittedInvoices.readFrom("submittedInvoices", code);
+    }
+  }
 }

--- a/src/test/java/io/vlingo/actors/DeadLettersTest.java
+++ b/src/test/java/io/vlingo/actors/DeadLettersTest.java
@@ -10,22 +10,25 @@ package io.vlingo.actors;
 import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.function.Consumer;
 
+import io.vlingo.actors.testkit.AccessSafely;
 import org.junit.Test;
 
 import io.vlingo.actors.testkit.TestActor;
-import io.vlingo.actors.testkit.TestUntil;
 
 public class DeadLettersTest extends ActorsTest {
-  private TestActor<DeadLettersListener> listener;
-  private TestActor<Nothing> nothing;
-  
+
   @Test
-  public void testStoppedActorToDeadLetters() throws Exception {
+  public void testStoppedActorToDeadLetters() {
     final TestResult result = new TestResult(3);
-    nothing = testWorld.actorFor(Nothing.class, Definition.has(NothingActor.class, Definition.NoParameters, "nothing"));
-    listener = testWorld.actorFor(DeadLettersListener.class, Definition.has(DeadLettersListenerActor.class, Definition.parameters(result), "deadletters-listener"));
+
+    TestActor<Nothing> nothing = testWorld
+            .actorFor(Nothing.class, Definition.has(NothingActor.class, Definition.NoParameters, "nothing"));
+    TestActor<DeadLettersListener> listener = testWorld.actorFor(DeadLettersListener.class,
+            Definition.has(DeadLettersListenerActor.class, Definition.parameters(result), "deadletters-listener"));
     world.world().deadLetters().registerListener(listener.actor());
 
     nothing.actor().stop();
@@ -33,15 +36,14 @@ public class DeadLettersTest extends ActorsTest {
     nothing.actor().doNothing(2);
     nothing.actor().doNothing(3);
 
-    result.until.completes();
+    final List<DeadLetter> deadLetters = result.getDeadLetters();
+    assertEquals(3, deadLetters.size());
 
-    assertEquals(3, result.deadLetters.size());
-
-    for (final DeadLetter deadLetter : result.deadLetters) {
+    for (final DeadLetter deadLetter : deadLetters) {
       assertEquals("doNothing(int)", deadLetter.representation);
     }
   }
-  
+
   public static interface Nothing extends Stoppable {
     void doNothing(final int withValue);
   }
@@ -61,18 +63,26 @@ public class DeadLettersTest extends ActorsTest {
 
     @Override
     public void handle(final DeadLetter deadLetter) {
-      result.deadLetters.add(deadLetter);
-      result.until.happened();
+      result.addDeadLetter(deadLetter);
     }
   }
 
-  public static class TestResult {
-    public final List<DeadLetter> deadLetters;
-    public final TestUntil until;
+  private static class TestResult {
+    private final AccessSafely deadLetters;
 
-    public TestResult(final int happenings) {
-      this.deadLetters = new ArrayList<>();
-      this.until = TestUntil.happenings(happenings);
+    private TestResult(final int happenings) {
+      final List<DeadLetter> deadLetters = Collections.synchronizedList(new ArrayList<>(happenings));
+      this.deadLetters = AccessSafely.afterCompleting(happenings);
+      this.deadLetters.writingWith("dl", (Consumer<DeadLetter>) deadLetters::add);
+      this.deadLetters.readingWith("dl", () -> deadLetters);
+    }
+
+    private List<DeadLetter> getDeadLetters(){
+      return this.deadLetters.readFrom("dl");
+    }
+
+    private void addDeadLetter(DeadLetter deadLetter){
+      this.deadLetters.writeUsing("dl", deadLetter);
     }
   }
 }

--- a/src/test/java/io/vlingo/actors/LocalMessageTest.java
+++ b/src/test/java/io/vlingo/actors/LocalMessageTest.java
@@ -14,95 +14,96 @@ import java.util.function.Consumer;
 
 import org.junit.Test;
 
-import io.vlingo.actors.testkit.TestUntil;
+import io.vlingo.actors.testkit.AccessSafely;
+import io.vlingo.actors.testkit.TestActor;
 
 public class LocalMessageTest extends ActorsTest {
   @Test
-  public void testDeliverHappy() throws Exception {
-    final SimpleTestResults testResults = new SimpleTestResults();
-    
-    testWorld.actorFor(Simple.class, Definition.has(SimpleActor.class, Definition.parameters(testResults), "test1-actor"));
-    
+  public void testDeliverHappy() {
+    final SimpleTestResults testResults = new SimpleTestResults(1);
+
+    final TestActor<Simple> testActor = testWorld.actorFor(Simple.class,
+            Definition.has(SimpleActor.class, Definition.parameters(testResults), "test1-actor"));
+
     final Consumer<Simple> consumer = (actor) -> actor.simple();
-    final LocalMessage<Simple> message = new LocalMessage<Simple>(SimpleActor.instance.get(), Simple.class, consumer, "simple()");
-    
-    testResults.untilSimple = TestUntil.happenings(1);
-    
+    final LocalMessage<Simple> message = new LocalMessage<Simple>(testActor.actorInside(), Simple.class, consumer, "simple()");
+
     message.deliver();
-    
-    testResults.untilSimple.completes();
-    
-    assertEquals(1, testResults.deliveries.get());
+
+    assertEquals(1, testResults.getDeliveries());
   }
 
   @Test
-  public void testDeliverStopped() throws Exception {
-    final SimpleTestResults testResults = new SimpleTestResults();
-    
-    testWorld.actorFor(Simple.class, Definition.has(SimpleActor.class, Definition.parameters(testResults), "test2-actor"));
-    
-    testResults.untilSimple = TestUntil.happenings(1);
-    
-    SimpleActor.instance.get().stop();
+  public void testDeliverStopped() {
+    final SimpleTestResults testResults = new SimpleTestResults(0);
+
+    final TestActor<Simple> testActor = testWorld.actorFor(Simple.class,
+            Definition.has(SimpleActor.class, Definition.parameters(testResults), "test2-actor"));
+
+    testActor.actorInside().stop();
         
-    final Consumer<Simple> consumer = (actor) -> actor.simple();
-    final LocalMessage<Simple> message = new LocalMessage<Simple>(SimpleActor.instance.get(), Simple.class, consumer, "simple()");
+    final Consumer<Simple> consumer = actor -> actor.simple();
+    final LocalMessage<Simple> message = new LocalMessage<Simple>(testActor.actorInside(), Simple.class, consumer, "simple()");
     
     message.deliver();
-    
-    assertEquals(1, testResults.untilSimple.remaining());
-    
-    assertEquals(0, testResults.deliveries.get());
+
+    assertEquals(0, testResults.getDeliveries());
   }
 
   @Test
-  public void testDeliverWithParameters() throws Exception {
-    final SimpleTestResults testResults = new SimpleTestResults();
-    
-    testWorld.actorFor(Simple.class, Definition.has(SimpleActor.class, Definition.parameters(testResults), "test3-actor"));
-    
-    testResults.untilSimple = TestUntil.happenings(1);
-    
+  public void testDeliverWithParameters() {
+    final SimpleTestResults testResults = new SimpleTestResults(1);
+
+    final TestActor<Simple> testActor = testWorld.actorFor(Simple.class,
+            Definition.has(SimpleActor.class, Definition.parameters(testResults), "test3-actor"));
+
     final Consumer<Simple> consumer = (actor) -> actor.simple2(2);
-    final LocalMessage<Simple> message = new LocalMessage<Simple>(SimpleActor.instance.get(), Simple.class, consumer, "simple2(int)");
+    final LocalMessage<Simple> message = new LocalMessage<Simple>(testActor.actorInside(), Simple.class, consumer, "simple2(int)");
     
     message.deliver();
-    
-    testResults.untilSimple.completes();
-    
-    assertEquals(1, testResults.deliveries.get());
+
+    assertEquals(1, testResults.getDeliveries());
   }
   
-  public static interface Simple {
+  public static interface Simple extends Stoppable{
     void simple();
     void simple2(final int val);
   }
 
   public static class SimpleActor extends Actor implements Simple {
-    public static final ThreadLocal<SimpleActor> instance = new ThreadLocal<>();
-    
     private final SimpleTestResults testResults;
     
     public SimpleActor(final SimpleTestResults testResults) {
       this.testResults = testResults;
-      instance.set(this);
     }
 
     @Override
     public void simple() {
-      testResults.deliveries.incrementAndGet();
-      testResults.untilSimple.happened();
+      testResults.increment();
     }
 
     @Override
     public void simple2(final int val) {
-      testResults.deliveries.incrementAndGet();
-      testResults.untilSimple.happened();
+      testResults.increment();
     }
   }
   
-  public static class SimpleTestResults {
-    public AtomicInteger deliveries = new AtomicInteger(0);
-    public TestUntil untilSimple = TestUntil.happenings(0);
+  private static class SimpleTestResults {
+    private AccessSafely deliveries;
+
+    private SimpleTestResults(final int times) {
+      final AtomicInteger deliveries = new AtomicInteger(0);
+      this.deliveries = AccessSafely.afterCompleting(times);
+      this.deliveries.writingWith("deliveries", (Integer i)-> deliveries.incrementAndGet());
+      this.deliveries.readingWith("deliveries", deliveries::get);
+    }
+
+    private void increment(){
+      this.deliveries.writeUsing("deliveries", 1);
+    }
+
+    private int getDeliveries(){
+      return this.deliveries.<Integer>readFrom("deliveries");
+    }
   }
 }

--- a/src/test/java/io/vlingo/actors/StageTest.java
+++ b/src/test/java/io/vlingo/actors/StageTest.java
@@ -25,7 +25,7 @@ import io.vlingo.actors.testkit.TestUntil;
 
 public class StageTest extends ActorsTest {
   @Test
-  public void testActorForDefinitionAndProtocol() throws Exception {
+  public void testActorForDefinitionAndProtocol() {
     final NoProtocol test = world.stage().actorFor(NoProtocol.class, TestInterfaceActor.class);
 
     assertNotNull(test);
@@ -34,7 +34,7 @@ public class StageTest extends ActorsTest {
   }
 
   @Test
-  public void testActorForNoDefinitionAndProtocol() throws Exception {
+  public void testActorForNoDefinitionAndProtocol() {
     final TestResults testResults = new TestResults();
     final Simple simple = world.stage().actorFor(Simple.class, SimpleActor.class, testResults);
     testResults.untilSimple = TestUntil.happenings(1);
@@ -51,7 +51,7 @@ public class StageTest extends ActorsTest {
   }
 
   @Test
-  public void testActorForAll() throws Exception {
+  public void testActorForAll() {
     world.actorFor(NoProtocol.class, ParentInterfaceActor.class);
 
     final Definition definition =
@@ -147,27 +147,22 @@ public class StageTest extends ActorsTest {
     world.stage().maybeActorOf(NoProtocol.class, address5).andThenConsume(maybe -> {
       assertTrue(maybe.isPresent());
       scanResult.scanFound.writeUsing("foundCount", 1);
-      until.happened();
     });
     world.stage().maybeActorOf(NoProtocol.class, address4).andThenConsume(maybe -> {
       assertTrue(maybe.isPresent());
       scanResult.scanFound.writeUsing("foundCount", 1);
-      until.happened();
     });
     world.stage().maybeActorOf(NoProtocol.class, address3).andThenConsume(maybe -> {
       assertTrue(maybe.isPresent());
       scanResult.scanFound.writeUsing("foundCount", 1);
-      until.happened();
     });
     world.stage().maybeActorOf(NoProtocol.class, address2).andThenConsume(maybe -> {
       assertTrue(maybe.isPresent());
       scanResult.scanFound.writeUsing("foundCount", 1);
-      until.happened();
     });
     world.stage().maybeActorOf(NoProtocol.class, address1).andThenConsume(maybe -> {
       assertTrue(maybe.isPresent());
       scanResult.scanFound.writeUsing("foundCount", 1);
-      until.happened();
     });
 
     world.stage().maybeActorOf(NoProtocol.class, address6)

--- a/src/test/java/io/vlingo/actors/WorldDefaultConfigurationTest.java
+++ b/src/test/java/io/vlingo/actors/WorldDefaultConfigurationTest.java
@@ -8,12 +8,7 @@
 package io.vlingo.actors;
 
 import static org.junit.Assert.assertTrue;
-
-import java.util.concurrent.atomic.AtomicBoolean;
-
 import org.junit.Test;
-
-import io.vlingo.actors.testkit.TestUntil;
 
 public class WorldDefaultConfigurationTest {
 
@@ -21,39 +16,13 @@ public class WorldDefaultConfigurationTest {
   public void testStartWorldWithDefaultConfiguration() {
     final World worldDefaultConfig = World.start("defaults");
     
-    final TestResults testResults = new TestResults();
+    final WorldTest.TestResults testResults = new WorldTest.TestResults(1);
     
-    final Simple simple = worldDefaultConfig.actorFor(Simple.class, SimpleActor.class, testResults);
-    
-    testResults.untilSimple = TestUntil.happenings(1);
-    
-    simple.simpleSay();
-    
-    testResults.untilSimple.completes();
-    
-    assertTrue(testResults.invoked.get());
-  }
-  
-  public static interface Simple {
-    void simpleSay();
-  }
-  
-  public static class SimpleActor extends Actor implements Simple {
-    private final TestResults testResults;
-    
-    public SimpleActor(final TestResults testResults) {
-      this.testResults = testResults;
-    }
-    
-    @Override
-    public void simpleSay() {
-      testResults.invoked.set(true);
-      testResults.untilSimple.happened();
-    }
-  }
+    final WorldTest.Simple simple = worldDefaultConfig.actorFor(WorldTest.Simple.class, WorldTest.SimpleActor.class, testResults);
 
-  public static class TestResults {
-    public AtomicBoolean invoked = new AtomicBoolean(false);
-    public TestUntil untilSimple = TestUntil.happenings(0);
+    simple.simpleSay();
+
+    assertTrue(testResults.getInvoked());
   }
+  
 }

--- a/src/test/java/io/vlingo/actors/plugin/completes/PooledCompletesProviderTest.java
+++ b/src/test/java/io/vlingo/actors/plugin/completes/PooledCompletesProviderTest.java
@@ -17,7 +17,6 @@ import io.vlingo.actors.ActorsTest;
 import io.vlingo.actors.CompletesEventually;
 import io.vlingo.actors.MockCompletes;
 import io.vlingo.actors.plugin.PluginProperties;
-import io.vlingo.actors.testkit.TestUntil;
 
 public class PooledCompletesProviderTest extends ActorsTest {
   
@@ -36,14 +35,13 @@ public class PooledCompletesProviderTest extends ActorsTest {
     
     plugin.start(world);
     
-    final MockCompletes<Object> clientCompletes = new MockCompletes<Object>();
+    final MockCompletes<Object> clientCompletes = new MockCompletes<>(1);
     
-    clientCompletes.untilWith = TestUntil.happenings(1);
     final CompletesEventually asyncCompletes = world.completesFor(clientCompletes);
-    asyncCompletes.with(new Integer(5));
-    clientCompletes.untilWith.completes();
-    assertEquals(1, ((MockCompletes<Object>) clientCompletes).withCount);
-    assertEquals(5, ((MockCompletes<Object>) clientCompletes).outcome);
+    asyncCompletes.with(5);
+
+    assertEquals(1, clientCompletes.getWithCount());
+    assertEquals(5, clientCompletes.outcome());
   }
 
   @Test
@@ -61,23 +59,19 @@ public class PooledCompletesProviderTest extends ActorsTest {
     
     plugin.start(world);
     
-    final MockCompletes<Object> clientCompletes1 = new MockCompletes<Object>();
-    final MockCompletes<Object> clientCompletes2 = new MockCompletes<Object>();
+    final MockCompletes<Object> clientCompletes1 = new MockCompletes<>(1);
+    final MockCompletes<Object> clientCompletes2 = new MockCompletes<>(1);
     
-    clientCompletes1.untilWith = TestUntil.happenings(1);
     final CompletesEventually completes1 = world.completesFor(clientCompletes1);
-    completes1.with(new Integer(5));
-    clientCompletes1.untilWith.completes();
+    completes1.with(5);
 
-    clientCompletes2.untilWith = TestUntil.happenings(1);
     final CompletesEventually completes2 = world.completesFor(completes1.address(), clientCompletes2);
-    completes2.with(new Integer(10));
-    clientCompletes2.untilWith.completes();
+    completes2.with(10);
 
-    assertEquals(1, ((MockCompletes<Object>) clientCompletes1).withCount);
-    assertEquals(5, ((MockCompletes<Object>) clientCompletes1).outcome);
-    assertEquals(1, ((MockCompletes<Object>) clientCompletes2).withCount);
-    assertEquals(10, ((MockCompletes<Object>) clientCompletes2).outcome);
+    assertEquals(1, clientCompletes1.getWithCount());
+    assertEquals(5, clientCompletes1.outcome());
+    assertEquals(1, clientCompletes2.getWithCount());
+    assertEquals(10, clientCompletes2.outcome());
     assertEquals(completes1, completes2);
   }
 }

--- a/src/test/java/io/vlingo/actors/plugin/mailbox/concurrentqueue/ExecutorDispatcherTest.java
+++ b/src/test/java/io/vlingo/actors/plugin/mailbox/concurrentqueue/ExecutorDispatcherTest.java
@@ -15,8 +15,8 @@ import java.util.List;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 import org.junit.Before;
@@ -29,7 +29,7 @@ import io.vlingo.actors.LocalMessage;
 import io.vlingo.actors.Logger;
 import io.vlingo.actors.Mailbox;
 import io.vlingo.actors.Message;
-import io.vlingo.actors.testkit.TestUntil;
+import io.vlingo.actors.testkit.AccessSafely;
 
 public class ExecutorDispatcherTest extends ActorsTest {
   private static int Total = 10_000;
@@ -37,17 +37,13 @@ public class ExecutorDispatcherTest extends ActorsTest {
   private Dispatcher dispatcher;
 
   @Test
-  public void testClose() throws Exception {
-    final TestResults testResults = new TestResults();
-
-    testResults.log.set(true);
+  public void testClose() {
+    final TestResults testResults = new TestResults(3, true);
 
     final TestMailbox mailbox = new TestMailbox(testResults, world.defaultLogger());
 
     final CountTakerActor actor = new CountTakerActor(testResults, world.defaultLogger());
-    
-    testResults.until = until(3);
-    
+
     for (int count = 0; count < 3; ++count) {
       final int countParam = count;
       final Consumer<CountTaker> consumer = (consumerActor) -> consumerActor.take(countParam);
@@ -56,8 +52,6 @@ public class ExecutorDispatcherTest extends ActorsTest {
       dispatcher.execute(mailbox);
     }
 
-    testResults.until.completes();
-    
     dispatcher.close();
     
     final Consumer<CountTaker> consumer = (consumerActor) -> consumerActor.take(10);
@@ -66,24 +60,23 @@ public class ExecutorDispatcherTest extends ActorsTest {
     mailbox.send(message);
     
     dispatcher.execute(mailbox);
-    
-    assertEquals(3, testResults.counts.size());
 
-    for (int idx = 0; idx < testResults.counts.size(); ++idx) {
-      assertTrue(testResults.counts.contains(idx));
+    final List<Integer> counts = testResults.getCounts();
+    assertEquals(3, counts.size());
+
+    for (int idx = 0; idx < counts.size(); ++idx) {
+      assertTrue(counts.contains(idx));
     }
   }
 
   @Test
-  public void testExecute() throws Exception {
-    final TestResults testResults = new TestResults();
+  public void testExecute() {
+    final TestResults testResults = new TestResults(Total, true);
     
     final TestMailbox mailbox = new TestMailbox(testResults, world.defaultLogger());
 
     final CountTakerActor actor = new CountTakerActor(testResults, world.defaultLogger());
-    
-    testResults.until = until(Total);
-    
+
     for (int count = 0; count < Total; ++count) {
       final int countParam = count;
       final Consumer<CountTaker> consumer = (consumerActor) -> consumerActor.take(countParam);
@@ -91,16 +84,17 @@ public class ExecutorDispatcherTest extends ActorsTest {
       mailbox.send(message);
       dispatcher.execute(mailbox);
     }
-    
-    testResults.until.completes();
-    
-    for (int idx = 0; idx < testResults.counts.size(); ++idx) {
-      assertTrue(testResults.counts.contains(idx));
+
+    final List<Integer> counts = testResults.getCounts();
+    assertEquals(Total, counts.size());
+
+    for (int idx = 0; idx < counts.size(); ++idx) {
+      assertTrue(counts.contains(idx));
     }
   }
   
   @Test
-  public void testRequiresExecutionNotification() throws Exception {
+  public void testRequiresExecutionNotification() {
     assertFalse(dispatcher.requiresExecutionNotification());
   }
   
@@ -112,12 +106,12 @@ public class ExecutorDispatcherTest extends ActorsTest {
     dispatcher = new ExecutorDispatcher(1, 1.0f);
   }
 
-  public static class TestMailbox implements Mailbox {
+  private static class TestMailbox implements Mailbox {
     private final Logger logger;
     private final Queue<Message> queue = new ConcurrentLinkedQueue<>();
     private final TestResults testResults;
 
-    public TestMailbox(final TestResults testResults, final Logger logger) {
+    private TestMailbox(final TestResults testResults, final Logger logger) {
       this.testResults = testResults;
       this.logger = logger;
     }
@@ -125,13 +119,13 @@ public class ExecutorDispatcherTest extends ActorsTest {
     @Override
     public void run() {
       final Message message = receive();
-      if (testResults.log.get()) {
+      if (testResults.shouldLog) {
         logger.log("TestMailbox: run: received: " + message);
       }
       if (message != null) {
         message.deliver();
-        if (testResults.log.get()) {
-          logger.log("TestMailbox: run: adding: " + testResults.highest.get());
+        if (testResults.shouldLog) {
+          logger.log("TestMailbox: run: adding: " + testResults.getHighest());
         }
       }
     }
@@ -198,24 +192,47 @@ public class ExecutorDispatcherTest extends ActorsTest {
     
     @Override
     public void take(final int count) {
-      if (testResults.log.get()) {
-        logger.log("CountTakerActor: take: " + count);
-      }
-      if (count > testResults.highest.get()) {
-        if (testResults.log.get()) {
-          logger.log("CountTakerActor: take: " + count + " > " + testResults.highest.get());
-        }
-        testResults.highest.set(count);
-      }
-      testResults.counts.add(testResults.highest.get());
-      testResults.until.happened();
+      testResults.take(count, this.logger);
     }
   }
   
   private static class TestResults {
-    public final AtomicBoolean log = new AtomicBoolean(false);
-    public final List<Integer> counts = new CopyOnWriteArrayList<>();
-    public AtomicInteger highest = new AtomicInteger(0);
-    public TestUntil until = TestUntil.happenings(0);
+    private final AccessSafely accessSafely;
+    private final boolean shouldLog;
+
+    private TestResults(final int happenings, boolean shouldLog) {
+      final List<Integer> counts = new CopyOnWriteArrayList<>();
+      final AtomicInteger highest = new AtomicInteger(0);
+      this.shouldLog = shouldLog;
+      this.accessSafely = AccessSafely
+              .afterCompleting(happenings)
+              .writingWith("results", (BiConsumer<Integer, Logger>) (count, logger) -> {
+                if (shouldLog) {
+                  logger.log("CountTakerActor: take: " + count);
+                }
+                if (count > highest.get()) {
+                  if (shouldLog) {
+                    logger.log("CountTakerActor: take: " + count + " > " + highest.get());
+                  }
+                  highest.set(count);
+                }
+
+                counts.add(highest.get());
+              })
+              .readingWith("results", () -> counts)
+              .readingWith("highest", highest::get);
+    }
+
+    void take(final Integer count, Logger logger){
+      this.accessSafely.writeUsing("results", count, logger);
+    }
+
+    List<Integer> getCounts(){
+      return this.accessSafely.readFrom("results");
+    }
+
+    int getHighest(){
+      return this.accessSafely.readFromNow("highest");
+    }
   }
 }


### PR DESCRIPTION
Fix for #44 .

Not that I have also added a new method to `AccessSafely` : 
`public <T,R> R readFromNow(final String name, final T parameter) `. 
It is used in one test and might be usefull in future.

There are still some test left using `TestUntil`, in the `io.vlingo.actors.plugin.mailbox` packages. Could not get a working solution using `AccessSafely`. 

I have tended to use one commit per unit test. Might use a squash merge to reduce the noise. 