### PR TITLE
Added Slf4j Logging plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.vlingo</groupId>
   <artifactId>vlingo-actors</artifactId>
-  <version>0.9.0</version>
+  <version>0.8.4</version>
   <name>vlingo-actors</name>
   <description>Type safe Actor Model toolkit for reactive concurrency and resiliency using Java and other JVM languages.</description>
   <url>https://github.com/vlingo/vlingo-actors</url>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>io.vlingo</groupId>
   <artifactId>vlingo-actors</artifactId>
-  <version>0.8.3</version>
+  <version>0.9.0</version>
   <name>vlingo-actors</name>
   <description>Type safe Actor Model toolkit for reactive concurrency and resiliency using Java and other JVM languages.</description>
   <url>https://github.com/vlingo/vlingo-actors</url>
@@ -85,6 +85,22 @@
   </repositories>
   <dependencies>
     <dependency>
+      <groupId>org.agrona</groupId>
+      <artifactId>agrona</artifactId>
+      <version>0.9.20</version>
+    </dependency>
+    <dependency>
+      <groupId>io.vlingo</groupId>
+      <artifactId>vlingo-common</artifactId>
+      <version>0.8.3</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.26</version>
+    </dependency>
+
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <version>4.11</version>
@@ -97,14 +113,10 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.agrona</groupId>
-      <artifactId>agrona</artifactId>
-      <version>0.9.20</version>
-    </dependency>
-    <dependency>
-      <groupId>io.vlingo</groupId>
-      <artifactId>vlingo-common</artifactId>
-      <version>0.8.3</version>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+      <version>1.0.13</version>
+      <scope>test</scope>
     </dependency>
   </dependencies>
   <distributionManagement>

--- a/src/main/java/io/vlingo/actors/Actor.java
+++ b/src/main/java/io/vlingo/actors/Actor.java
@@ -335,7 +335,7 @@ public abstract class Actor implements Startable, Stoppable, TestStateView {
   protected void beforeRestart(final Throwable reason) {
     // override for specific recovery
 
-    logger().log("Default before restart recovery after: " + reason.getMessage(), reason);
+    logger().error("Default before restart recovery after: " + reason.getMessage(), reason);
 
     lifeCycle.afterStop(this);
   }
@@ -348,7 +348,7 @@ public abstract class Actor implements Startable, Stoppable, TestStateView {
   protected void afterRestart(final Throwable reason) {
     // override for specific recovery
 
-    logger().log("Default after restart recovery after: " + reason.getMessage(), reason);
+    logger().error("Default after restart recovery after: " + reason.getMessage(), reason);
 
     lifeCycle.beforeStart(this);
   }
@@ -361,6 +361,6 @@ public abstract class Actor implements Startable, Stoppable, TestStateView {
   protected void beforeResume(final Throwable reason) {
     // override for specific recovery
 
-    logger().log("Default before resume recovery after: " + reason.getMessage(), reason);
+    logger().error("Default before resume recovery after: " + reason.getMessage(), reason);
   }
 }

--- a/src/main/java/io/vlingo/actors/ActorFactory.java
+++ b/src/main/java/io/vlingo/actors/ActorFactory.java
@@ -126,7 +126,7 @@ public class ActorFactory {
     }
 
     if (cause != null) {
-      logger.log("ActorFactory: failed actor creation. "
+      logger.error("ActorFactory: failed actor creation. "
               + "This is sometimes cause be the constructor parameter types not matching "
               + "the types in the Definition.parameters(). Often it is caused by a "
               + "failure in the actor constructor. We have attempted to uncover "

--- a/src/main/java/io/vlingo/actors/CompletesEventuallyActor.java
+++ b/src/main/java/io/vlingo/actors/CompletesEventuallyActor.java
@@ -16,7 +16,7 @@ public class CompletesEventuallyActor extends Actor implements CompletesEventual
       final PooledCompletes pooled = (PooledCompletes) outcome;
       pooled.clientCompletes.with(pooled.outcome());
     } catch (Throwable t) {
-      logger().log("The eventually completed outcome failed in the client because: " + t.getMessage(), t);
+      logger().error("The eventually completed outcome failed in the client because: " + t.getMessage(), t);
     }
   }
 }

--- a/src/main/java/io/vlingo/actors/Configuration.java
+++ b/src/main/java/io/vlingo/actors/Configuration.java
@@ -24,6 +24,7 @@ import io.vlingo.actors.plugin.PluginLoader;
 import io.vlingo.actors.plugin.PluginProperties;
 import io.vlingo.actors.plugin.completes.PooledCompletesPlugin.PooledCompletesPluginConfiguration;
 import io.vlingo.actors.plugin.logging.jdk.JDKLoggerPlugin.JDKLoggerPluginConfiguration;
+import io.vlingo.actors.plugin.logging.slf4j.Slf4jLoggerPlugin;
 import io.vlingo.actors.plugin.mailbox.agronampscarrayqueue.ManyToOneConcurrentArrayQueuePlugin.ManyToOneConcurrentArrayQueuePluginConfiguration;
 import io.vlingo.actors.plugin.mailbox.concurrentqueue.ConcurrentQueueMailboxPlugin.ConcurrentQueueMailboxPluginConfiguration;
 import io.vlingo.actors.plugin.mailbox.sharedringbuffer.SharedRingBufferMailboxPlugin.SharedRingBufferMailboxPluginConfiguration;
@@ -35,6 +36,7 @@ public class Configuration {
   private CommonSupervisorsPluginConfiguration commonSupervisorsPluginConfiguration;
   private DefaultSupervisorOverridePluginConfiguration defaultSupervisorOverridePluginConfiguration;
   private JDKLoggerPluginConfiguration jdkLoggerPluginConfiguration;
+  private Slf4jLoggerPlugin.Slf4jLoggerPluginConfiguration slf4jPluginConfiguration;
   private PooledCompletesPluginConfiguration pooledCompletesPluginConfiguration;
   private ManyToOneConcurrentArrayQueuePluginConfiguration manyToOneConcurrentArrayQueuePluginConfiguration;
   private SharedRingBufferMailboxPluginConfiguration sharedRingBufferMailboxPluginConfiguration;
@@ -106,6 +108,19 @@ public class Configuration {
 
   public JDKLoggerPluginConfiguration jdkLoggerPluginConfiguration() {
     return jdkLoggerPluginConfiguration;
+  }
+
+  public Configuration with(final Slf4jLoggerPlugin.Slf4jLoggerPluginConfiguration configuration) {
+    if (this.slf4jPluginConfiguration != null) {
+
+    }
+    this.slf4jPluginConfiguration = configuration;
+    this.configurationOverrides.put(configuration.getClass().getSimpleName(), configuration);
+    return this;
+  }
+
+  public Slf4jLoggerPlugin.Slf4jLoggerPluginConfiguration slf4jPluginConfiguration() {
+    return slf4jPluginConfiguration;
   }
 
   public Configuration with(final ManyToOneConcurrentArrayQueuePluginConfiguration configuration) {
@@ -214,8 +229,8 @@ public class Configuration {
   private Configuration(final Properties properties, final boolean includeBaseLoad) {
     this.configurationOverrides = new HashMap<>();
     this.plugins = new ArrayList<>();
-    this.properties = null;
-    this.mergeProperties = false;
+    this.properties = properties;
+    this.mergeProperties = includeBaseLoad;
 
     this
       .usingMainProxyGeneratedClassesPath("target/classes/")
@@ -237,6 +252,7 @@ public class Configuration {
     final List<Class<?>> pluginClasses = Arrays.asList(
             io.vlingo.actors.plugin.completes.PooledCompletesPlugin.class,
             io.vlingo.actors.plugin.logging.jdk.JDKLoggerPlugin.class,
+            io.vlingo.actors.plugin.logging.slf4j.Slf4jLoggerPlugin.class,
             io.vlingo.actors.plugin.mailbox.agronampscarrayqueue.ManyToOneConcurrentArrayQueuePlugin.class,
             io.vlingo.actors.plugin.mailbox.concurrentqueue.ConcurrentQueueMailboxPlugin.class,
             io.vlingo.actors.plugin.mailbox.sharedringbuffer.SharedRingBufferMailboxPlugin.class,

--- a/src/main/java/io/vlingo/actors/DeadLettersActor.java
+++ b/src/main/java/io/vlingo/actors/DeadLettersActor.java
@@ -20,14 +20,14 @@ public class DeadLettersActor extends Actor implements DeadLetters {
   }
 
   public void failedDelivery(final DeadLetter deadLetter) {
-    logger().log(deadLetter.toString());
+    logger().debug(deadLetter.toString());
 
     for (final DeadLettersListener listener : listeners) {
       try {
         listener.handle(deadLetter);
       } catch (Throwable t) {
         // ignore, but log
-        logger().log("DeadLetters listener failed to handle: " + deadLetter, t);
+        logger().warn("DeadLetters listener failed to handle: " + deadLetter, t);
       }
     }
   }

--- a/src/main/java/io/vlingo/actors/DefaultSupervisor.java
+++ b/src/main/java/io/vlingo/actors/DefaultSupervisor.java
@@ -28,7 +28,7 @@ public abstract class DefaultSupervisor extends Actor implements Supervisor {
 
   @Override
   public void inform(final Throwable throwable, final Supervised supervised) {
-    logger().log("DefaultSupervisor: Failure of: " + supervised.address() + " because: " + throwable.getMessage() + " Action: Possibly restarting.", throwable);
+    logger().error("DefaultSupervisor: Failure of: " + supervised.address() + " because: " + throwable.getMessage() + " Action: Possibly restarting.", throwable);
     supervised.restartWithin(DefaultSupervisionStrategy.period(), DefaultSupervisionStrategy.intensity(), DefaultSupervisionStrategy.scope());
   }
 

--- a/src/main/java/io/vlingo/actors/Directory.java
+++ b/src/main/java/io/vlingo/actors/Directory.java
@@ -37,7 +37,7 @@ final class Directory {
         for (final Actor actor : map.values()) {
           final Address address = actor.address();
           final Address parent = actor.lifeCycle.environment.parent == null ? none : actor.lifeCycle.environment.parent.address();
-          logger.log("DIR: DUMP: ACTOR: " + address + " PARENT: " + parent + " TYPE: " + actor.getClass());
+          logger.debug("DIR: DUMP: ACTOR: " + address + " PARENT: " + parent + " TYPE: " + actor.getClass());
         }
       }
     }

--- a/src/main/java/io/vlingo/actors/DirectoryScannerActor.java
+++ b/src/main/java/io/vlingo/actors/DirectoryScannerActor.java
@@ -50,10 +50,10 @@ public class DirectoryScannerActor extends Actor implements DirectoryScanner {
       if (actor != null) {
         return stage().actorAs(actor, protocol);
       } else {
-        logger().log("Actor with address: " + address + " not found; protocol is: " + protocol.getName());
+        logger().debug("Actor with address: " + address + " not found; protocol is: " + protocol.getName());
       }
     } catch (Exception e) {
-      logger().log("Error providing protocol: " + protocol.getName() + " for actor with address: " + address, e);
+      logger().error("Error providing protocol: " + protocol.getName() + " for actor with address: " + address, e);
     }
     return null;
   }

--- a/src/main/java/io/vlingo/actors/LifeCycle.java
+++ b/src/main/java/io/vlingo/actors/LifeCycle.java
@@ -64,7 +64,7 @@ final class LifeCycle {
     try {
       actor.afterStop();
     } catch (Throwable t) {
-      environment.logger.log("vlingo/actors: Actor afterStop() failed: " + t.getMessage(), t);
+      environment.logger.error("vlingo/actors: Actor afterStop() failed: " + t.getMessage(), t);
       environment.stage.handleFailureOf(new StageSupervisedActor(Stoppable.class, actor, t));
     }
   }
@@ -73,7 +73,7 @@ final class LifeCycle {
     try {
       actor.beforeStart();
     } catch (Throwable t) {
-      environment.logger.log("vlingo/actors: Actor beforeStart() failed: " + t.getMessage());
+      environment.logger.error("vlingo/actors: Actor beforeStart() failed: " + t.getMessage());
       environment.stage.handleFailureOf(new StageSupervisedActor(Startable.class, actor, t));
     }
   }
@@ -82,7 +82,7 @@ final class LifeCycle {
     try {
       actor.afterRestart(throwable);
     } catch (Throwable t) {
-      environment.logger.log("vlingo/actors: Actor beforeStart() failed: " + t.getMessage());
+      environment.logger.error("vlingo/actors: Actor beforeStart() failed: " + t.getMessage());
       environment.stage.handleFailureOf(new StageSupervisedActor(Startable.class, actor, t));
     }
   }
@@ -91,7 +91,7 @@ final class LifeCycle {
     try {
       actor.beforeRestart(reason);
     } catch (Throwable t) {
-      environment.logger.log("vlingo/actors: Actor beforeRestart() failed: " + t.getMessage());
+      environment.logger.error("vlingo/actors: Actor beforeRestart() failed: " + t.getMessage());
       environment.stage.handleFailureOf(new StageSupervisedActor(protocol, actor, t));
     }
   }
@@ -100,7 +100,7 @@ final class LifeCycle {
     try {
       actor.beforeResume(reason);
     } catch (Throwable t) {
-      environment.logger.log("vlingo/actors: Actor beforeResume() failed: " + t.getMessage());
+      environment.logger.error("vlingo/actors: Actor beforeResume() failed: " + t.getMessage());
       environment.stage.handleFailureOf(new StageSupervisedActor(protocol, actor, t));
     }
   }
@@ -115,7 +115,7 @@ final class LifeCycle {
         environment.mailbox.send(targetActor, Startable.class, consumer, null, "start()");
       }
     } catch (Throwable t) {
-      environment.logger.log("vlingo/actors: Actor start() failed: " + t.getMessage());
+      environment.logger.error("vlingo/actors: Actor start() failed: " + t.getMessage());
       environment.stage.handleFailureOf(new StageSupervisedActor(Startable.class, targetActor, t));
     }
   }

--- a/src/main/java/io/vlingo/actors/LocalMessage.java
+++ b/src/main/java/io/vlingo/actors/LocalMessage.java
@@ -99,7 +99,7 @@ public class LocalMessage<T> implements Message {
     if (deadLetters != null) {
       deadLetters.failedDelivery(deadLetter);
     } else {
-      actor.logger().log("vlingo/actors: MISSING DEAD LETTERS FOR: " + deadLetter);
+      actor.logger().warn("vlingo/actors: MISSING DEAD LETTERS FOR: " + deadLetter);
     }
   }
 
@@ -126,7 +126,7 @@ public class LocalMessage<T> implements Message {
           //actor.lifeCycle.environment.stage.world().completesFor(completes).with(actor.completes.__internal__outcome);
         }
       } catch (Throwable t) {
-        actor.logger().log("Message#deliver(): Exception: " + t.getMessage() + " for Actor: " + actor + " sending: " + representation, t);
+        actor.logger().error("Message#deliver(): Exception: " + t.getMessage() + " for Actor: " + actor + " sending: " + representation, t);
         actor.stage().handleFailureOf(new StageSupervisedActor(protocol, actor, t));
       }
     }

--- a/src/main/java/io/vlingo/actors/Logger.java
+++ b/src/main/java/io/vlingo/actors/Logger.java
@@ -8,15 +8,15 @@
 package io.vlingo.actors;
 
 import io.vlingo.actors.plugin.logging.noop.NoOpLogger;
-import io.vlingo.actors.plugin.logging.slf4j.Slf4jLogger;
+import io.vlingo.actors.plugin.logging.slf4j.Slf4jLoggerPlugin;
 
 public interface Logger {
-  public static Logger noOpLogger() {
+  static Logger noOpLogger() {
     return new NoOpLogger();
   }
 
-  public static Logger basicLogger() {
-    return Slf4jLogger.basicInstance();
+  static Logger basicLogger() {
+    return Slf4jLoggerPlugin.basicInstance();
   }
   
   String name();

--- a/src/main/java/io/vlingo/actors/Logger.java
+++ b/src/main/java/io/vlingo/actors/Logger.java
@@ -7,8 +7,8 @@
 
 package io.vlingo.actors;
 
-import io.vlingo.actors.plugin.logging.jdk.JDKLogger;
 import io.vlingo.actors.plugin.logging.noop.NoOpLogger;
+import io.vlingo.actors.plugin.logging.slf4j.Slf4jLogger;
 
 public interface Logger {
   public static Logger noOpLogger() {
@@ -16,18 +16,16 @@ public interface Logger {
   }
 
   public static Logger basicLogger() {
-    return JDKLogger.basicInstance();
+    return Slf4jLogger.basicInstance();
   }
-
-  public static Logger testLogger() {
-    return JDKLogger.testInstance();
-  }
-
+  
   String name();
   void close();
   boolean isEnabled();
 
+  @Deprecated
   void log(final String message);
+  @Deprecated
   void log(final String message, final Throwable throwable);
 
   void trace(String message);

--- a/src/main/java/io/vlingo/actors/LoggerProvider.java
+++ b/src/main/java/io/vlingo/actors/LoggerProvider.java
@@ -7,18 +7,19 @@
 
 package io.vlingo.actors;
 
-import io.vlingo.actors.plugin.logging.jdk.JDKLoggerPlugin;
 import io.vlingo.actors.plugin.logging.noop.NoOpLoggerProvider;
+import io.vlingo.actors.plugin.logging.slf4j.Slf4jLoggerPlugin;
 
 public interface LoggerProvider {
-  public static LoggerProvider noOpLoggerProvider() {
+  static LoggerProvider noOpLoggerProvider() {
     return new NoOpLoggerProvider();
   }
 
-  public static LoggerProvider standardLoggerProvider(final World world, final String name) {
-    return JDKLoggerPlugin.registerStandardLogger(name, world);
+  static LoggerProvider standardLoggerProvider(final World world, final String name) {
+    return Slf4jLoggerPlugin.registerStandardLogger(name, world);
   }
 
   void close();
+  
   Logger logger();
 }

--- a/src/main/java/io/vlingo/actors/PrivateRootActor.java
+++ b/src/main/java/io/vlingo/actors/PrivateRootActor.java
@@ -60,7 +60,7 @@ public class PrivateRootActor extends Actor implements Stoppable, Supervisor {
 
   @Override
   public void inform(Throwable throwable, Supervised supervised) {
-    logger().log("PrivateRootActor: Failure of: " + supervised.address() + " because: " + throwable.getMessage() + " Action: Stopping.", throwable);
+    logger().error("PrivateRootActor: Failure of: " + supervised.address() + " because: " + throwable.getMessage() + " Action: Stopping.", throwable);
     supervised.stop(strategy.scope());
   }
 

--- a/src/main/java/io/vlingo/actors/ProxyGenerator.java
+++ b/src/main/java/io/vlingo/actors/ProxyGenerator.java
@@ -1,4 +1,5 @@
 // Copyright © 2012-2018 Vaughn Vernon. All rights reserved.
+// Copyright © 2012-2018 Vaughn Vernon. All rights reserved.
 //
 // This Source Code Form is subject to the terms of the
 // Mozilla Public License, v. 2.0. If a copy of the MPL
@@ -90,7 +91,7 @@ public class ProxyGenerator implements AutoCloseable {
   }
 
   public Result generateFor(final String actorProtocol) {
-    logger.log("vlingo/actors: Generating proxy for " + (type == DynaType.Main ? "main":"test") + ": " + actorProtocol);
+    logger.debug("vlingo/actors: Generating proxy for " + (type == DynaType.Main ? "main":"test") + ": " + actorProtocol);
 
     try {
       final Class<?> protocolInterface = readProtocolInterface(actorProtocol);

--- a/src/main/java/io/vlingo/actors/PublicRootActor.java
+++ b/src/main/java/io/vlingo/actors/PublicRootActor.java
@@ -43,7 +43,7 @@ public class PublicRootActor extends Actor implements Stoppable, Supervisor {
 
   @Override
   public void inform(final Throwable throwable, final Supervised supervised) {
-    logger().log("PublicRootActor: Failure of: " + supervised.address() + " because: " + throwable.getMessage() + " Action: Restarting.", throwable);
+    logger().error("PublicRootActor: Failure of: " + supervised.address() + " because: " + throwable.getMessage() + " Action: Restarting.", throwable);
     supervised.restartWithin(supervisionStrategy.period(), supervisionStrategy.intensity(), supervisionStrategy.scope());
   }
 

--- a/src/main/java/io/vlingo/actors/Stage.java
+++ b/src/main/java/io/vlingo/actors/Stage.java
@@ -246,7 +246,7 @@ public class Stage implements Stoppable {
               ).toTestActor();
 
     } catch (Exception e) {
-      world.defaultLogger().log("vlingo/actors: FAILED: " + e.getMessage(), e);
+      world.defaultLogger().error("vlingo/actors: FAILED: " + e.getMessage(), e);
       e.printStackTrace();
       return null;
     }
@@ -295,7 +295,7 @@ public class Stage implements Stoppable {
   public void dump() {
     final Logger logger = this.world.defaultLogger();
     if (logger.isEnabled()) {
-      logger.log("STAGE: " + name);
+      logger.debug("STAGE: " + name);
       directory.dump(logger);
     }
   }
@@ -439,7 +439,7 @@ public class Stage implements Stoppable {
       return new ActorProtocolActor<T>(actor, protocolActor);
     } catch (Exception e) {
       e.printStackTrace();
-      world.defaultLogger().log("vlingo/actors: FAILED: " + e.getMessage(), e);
+      world.defaultLogger().error("vlingo/actors: FAILED: " + e.getMessage(), e);
       return null;
     }
   }
@@ -469,7 +469,7 @@ public class Stage implements Stoppable {
       final Object[] protocolActors = actorProxyFor(protocols, actor, actor.lifeCycle.environment.mailbox);
       return ActorProtocolActor.allOf(protocolActors, actor);
     } catch (Exception e) {
-      world.defaultLogger().log("vlingo/actors: FAILED: " + e.getMessage(), e);
+      world.defaultLogger().error("vlingo/actors: FAILED: " + e.getMessage(), e);
       return null;
     }
   }
@@ -644,7 +644,7 @@ public class Stage implements Stoppable {
     try {
       actor = ActorFactory.actorFor(this, parent, definition, address, mailbox, maybeSupervisor, logger);
     } catch (Exception e) {
-      logger.log("Actor instantiation failed because: " + e.getMessage(), e);
+      logger.error("Actor instantiation failed because: " + e.getMessage(), e);
       throw new IllegalArgumentException("Actor instantiation failed because: " + e.getMessage(), e);
     }
 

--- a/src/main/java/io/vlingo/actors/Stowage.java
+++ b/src/main/java/io/vlingo/actors/Stowage.java
@@ -33,7 +33,7 @@ public class Stowage {
 
   void dump(final Logger logger) {
     for (final Message message : stowedMessages) {
-      logger.log("STOWED: " + message);
+      logger.debug("STOWED: " + message);
     }
   }
 

--- a/src/main/java/io/vlingo/actors/World.java
+++ b/src/main/java/io/vlingo/actors/World.java
@@ -315,7 +315,7 @@ public final class World implements Registrar {
       final Supervisor common = stage.actorFor(Supervisor.class, Definition.has(supervisorClass, Definition.NoParameters, name));
       stage.registerCommonSupervisor(supervisedProtocol, common);
     } catch (Exception e) {
-      defaultLogger().log("vlingo/actors: World cannot register common supervisor: " + supervisedProtocol.getName(), e);
+      defaultLogger().error("vlingo/actors: World cannot register common supervisor: " + supervisedProtocol.getName(), e);
     }
   }
 
@@ -333,8 +333,7 @@ public final class World implements Registrar {
       final Stage stage = stageNamed(actualStageName);
       defaultSupervisor = stage.actorFor(Supervisor.class, Definition.has(supervisorClass, Definition.NoParameters, name));
     } catch (Exception e) {
-      defaultLogger().log("vlingo/actors: World cannot register default supervisor override: " + supervisorClass.getName(), e);
-      e.printStackTrace();
+      defaultLogger().error("vlingo/actors: World cannot register default supervisor override: " + supervisorClass.getName(), e);
     }
   }
 

--- a/src/main/java/io/vlingo/actors/plugin/logging/jdk/JDKLogger.java
+++ b/src/main/java/io/vlingo/actors/plugin/logging/jdk/JDKLogger.java
@@ -7,32 +7,20 @@
 
 package io.vlingo.actors.plugin.logging.jdk;
 
+import io.vlingo.actors.Logger;
+import io.vlingo.actors.plugin.logging.jdk.JDKLoggerPlugin.JDKLoggerPluginConfiguration;
+
 import java.util.logging.FileHandler;
 import java.util.logging.Handler;
 import java.util.logging.Level;
 import java.util.logging.MemoryHandler;
-
-import io.vlingo.actors.Configuration;
-import io.vlingo.actors.Logger;
-import io.vlingo.actors.plugin.logging.jdk.JDKLoggerPlugin.JDKLoggerPluginConfiguration;
 
 public class JDKLogger implements Logger {
   private final Handler handler;
   private final Level level;
   private final java.util.logging.Logger logger;
   private final String name;
-
-  public static Logger basicInstance() {
-    final Configuration configuration = Configuration.define();
-    final JDKLoggerPluginConfiguration loggerConfiguration = JDKLoggerPluginConfiguration.define();
-    loggerConfiguration.build(configuration);
-    return new JDKLogger(loggerConfiguration.name(), loggerConfiguration);
-  }
-
-  public static Logger testInstance() {
-    return basicInstance();
-  }
-
+  
   protected JDKLogger(final String name, final JDKLoggerPluginConfiguration configuration) {
     this.name = name;
     this.logger = java.util.logging.Logger.getLogger(name);

--- a/src/main/java/io/vlingo/actors/plugin/logging/jdk/JDKLoggerPlugin.java
+++ b/src/main/java/io/vlingo/actors/plugin/logging/jdk/JDKLoggerPlugin.java
@@ -25,6 +25,17 @@ public class JDKLoggerPlugin extends AbstractPlugin implements Plugin, LoggerPro
   private Logger logger;
   private int pass = 1;
 
+  public static Logger basicInstance() {
+    final Configuration configuration = Configuration.define();
+    final JDKLoggerPluginConfiguration loggerConfiguration = JDKLoggerPluginConfiguration.define();
+    loggerConfiguration.build(configuration);
+    return new JDKLogger(loggerConfiguration.name(), loggerConfiguration);
+  }
+
+  public static Logger testInstance() {
+    return basicInstance();
+  }
+
   public static LoggerProvider registerStandardLogger(final String name, final Registrar registrar) {
     final JDKLoggerPlugin plugin = new JDKLoggerPlugin();
     final JDKLoggerPluginConfiguration pluginConfiguration = (JDKLoggerPluginConfiguration) plugin.configuration();

--- a/src/main/java/io/vlingo/actors/plugin/logging/slf4j/Slf4jLogger.java
+++ b/src/main/java/io/vlingo/actors/plugin/logging/slf4j/Slf4jLogger.java
@@ -12,14 +12,15 @@ import org.slf4j.LoggerFactory;
 
 public class Slf4jLogger implements Logger {
   private final org.slf4j.Logger logger = LoggerFactory.getLogger(Logger.class);
-
-  public static Logger basicInstance() {
-    return new Slf4jLogger();
+  private final String name;
+  
+  Slf4jLogger(final String name){
+    this.name = name;
   }
 
   @Override
   public String name() {
-    return this.logger.getName();
+    return name;
   }
 
   @Override
@@ -49,7 +50,7 @@ public class Slf4jLogger implements Logger {
 
   @Override
   public void trace(String message, Object... args) {
-    this.trace(message, args);
+    this.logger.trace(message, args);
   }
 
   @Override

--- a/src/main/java/io/vlingo/actors/plugin/logging/slf4j/Slf4jLogger.java
+++ b/src/main/java/io/vlingo/actors/plugin/logging/slf4j/Slf4jLogger.java
@@ -1,0 +1,119 @@
+// Copyright © 2012-2018 Vaughn Vernon. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0. If a copy of the MPL
+// was not distributed with this file, You can obtain
+// one at https://mozilla.org/MPL/2.0/.
+
+package io.vlingo.actors.plugin.logging.slf4j;
+
+import io.vlingo.actors.Logger;
+import org.slf4j.LoggerFactory;
+
+public class Slf4jLogger implements Logger {
+  private final org.slf4j.Logger logger = LoggerFactory.getLogger(Logger.class);
+
+  public static Logger basicInstance() {
+    return new Slf4jLogger();
+  }
+
+  @Override
+  public String name() {
+    return this.logger.getName();
+  }
+
+  @Override
+  public void close() {
+
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return true;
+  }
+
+  @Override
+  public void log(String message) {
+    debug(message);
+  }
+
+  @Override
+  public void log(String message, Throwable throwable) {
+    debug(message, throwable);
+  }
+
+  @Override
+  public void trace(String message) {
+    this.logger.trace(message);
+  }
+
+  @Override
+  public void trace(String message, Object... args) {
+    this.trace(message, args);
+  }
+
+  @Override
+  public void trace(String message, Throwable throwable) {
+    this.logger.trace(message, throwable);
+  }
+
+  @Override
+  public void debug(String message) {
+    this.logger.debug(message);
+  }
+
+  @Override
+  public void debug(String message, Object... args) {
+    this.logger.debug(message, args);
+  }
+
+  @Override
+  public void debug(String message, Throwable throwable) {
+    this.logger.debug(message, throwable);
+  }
+
+  @Override
+  public void info(String message) {
+    this.logger.info(message);
+  }
+
+  @Override
+  public void info(String message, Object... args) {
+    this.logger.info(message, args);
+  }
+
+  @Override
+  public void info(String message, Throwable throwable) {
+    this.logger.info(message, throwable);
+  }
+
+  @Override
+  public void warn(String message) {
+    this.logger.warn(message);
+  }
+
+  @Override
+  public void warn(String message, Object... args) {
+    this.logger.warn(message, args);
+  }
+
+  @Override
+  public void warn(String message, Throwable throwable) {
+    this.logger.warn(message, throwable);
+  }
+
+  @Override
+  public void error(String message) {
+    this.logger.error(message);
+  }
+
+  @Override
+  public void error(String message, Object... args) {
+    this.logger.error(message, args);
+  }
+
+  @Override
+  public void error(String message, Throwable throwable) {
+    this.logger.error(message, throwable);
+  }
+}

--- a/src/main/java/io/vlingo/actors/plugin/logging/slf4j/Slf4jLoggerActor.java
+++ b/src/main/java/io/vlingo/actors/plugin/logging/slf4j/Slf4jLoggerActor.java
@@ -1,0 +1,126 @@
+// Copyright © 2012-2018 Vaughn Vernon. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0. If a copy of the MPL
+// was not distributed with this file, You can obtain
+// one at https://mozilla.org/MPL/2.0/.
+
+package io.vlingo.actors.plugin.logging.slf4j;
+
+import io.vlingo.actors.Actor;
+import io.vlingo.actors.Logger;
+
+public class Slf4jLoggerActor extends Actor implements Logger {
+
+  private final Logger logger;
+
+  public Slf4jLoggerActor(Logger logger) {
+    this.logger = logger;
+  }
+
+  @Override
+  public void stop() {
+    close();
+    super.stop();
+  }
+
+  @Override
+  public String name() {
+    return this.logger.name();
+  }
+
+  @Override
+  public void close() {
+    this.logger.close();
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return this.logger.isEnabled();
+  }
+
+  @Override
+  public void log(String message) {
+    this.logger.log(message);
+  }
+
+  @Override
+  public void log(String message, Throwable throwable) {
+    this.logger.log(message, throwable);
+  }
+
+  @Override
+  public void trace(String message) {
+    this.logger.trace(message);
+  }
+
+  @Override
+  public void trace(String message, Object... args) {
+    this.logger.trace(message, args);
+  }
+
+  @Override
+  public void trace(String message, Throwable throwable) {
+    this.logger.trace(message, throwable);
+  }
+
+  @Override
+  public void debug(String message) {
+    this.logger.debug(message);
+  }
+
+  @Override
+  public void debug(String message, Object... args) {
+    this.logger.debug(message, args);
+  }
+
+  @Override
+  public void debug(String message, Throwable throwable) {
+    this.logger.debug(message, throwable);
+  }
+
+  @Override
+  public void info(String message) {
+    this.logger.info(message);
+  }
+
+  @Override
+  public void info(String message, Object... args) {
+    this.logger.info(message, args);
+  }
+
+  @Override
+  public void info(String message, Throwable throwable) {
+    this.logger.info(message, throwable);
+  }
+
+  @Override
+  public void warn(String message) {
+    this.logger.warn(message);
+  }
+
+  @Override
+  public void warn(String message, Object... args) {
+    this.logger.warn(message, args);
+  }
+
+  @Override
+  public void warn(String message, Throwable throwable) {
+    this.logger.warn(message, throwable);
+  }
+
+  @Override
+  public void error(String message) {
+    this.logger.error(message);
+  }
+
+  @Override
+  public void error(String message, Object... args) {
+    this.logger.error(message, args);
+  }
+
+  @Override
+  public void error(String message, Throwable throwable) {
+    this.logger.error(message, throwable);
+  }
+}

--- a/src/main/java/io/vlingo/actors/plugin/logging/slf4j/Slf4jLoggerPlugin.java
+++ b/src/main/java/io/vlingo/actors/plugin/logging/slf4j/Slf4jLoggerPlugin.java
@@ -1,0 +1,116 @@
+// Copyright © 2012-2018 Vaughn Vernon. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0. If a copy of the MPL
+// was not distributed with this file, You can obtain
+// one at https://mozilla.org/MPL/2.0/.
+package io.vlingo.actors.plugin.logging.slf4j;
+
+import io.vlingo.actors.Configuration;
+import io.vlingo.actors.Definition;
+import io.vlingo.actors.Logger;
+import io.vlingo.actors.LoggerProvider;
+import io.vlingo.actors.Registrar;
+import io.vlingo.actors.plugin.AbstractPlugin;
+import io.vlingo.actors.plugin.Plugin;
+import io.vlingo.actors.plugin.PluginConfiguration;
+import io.vlingo.actors.plugin.PluginProperties;
+
+public class Slf4jLoggerPlugin extends AbstractPlugin implements Plugin, LoggerProvider {
+  private final Slf4jLoggerPluginConfiguration pluginConfiguration;
+  private int pass = 1;
+  private Logger logger;
+
+  /**
+   * Required for plugin creation at runtime.
+   */
+  public Slf4jLoggerPlugin() {
+    this.pluginConfiguration = new Slf4jLoggerPluginConfiguration();
+  }
+
+  private Slf4jLoggerPlugin(final PluginConfiguration configuration) {
+    this.pluginConfiguration = ((Slf4jLoggerPluginConfiguration) configuration);
+  }
+
+  @Override
+  public Logger logger() {
+    return this.logger;
+  }
+
+  @Override
+  public void close() {
+    this.logger.close();
+  }
+
+  @Override
+  public PluginConfiguration configuration() {
+    return pluginConfiguration;
+  }
+
+  @Override
+  public String name() {
+    return pluginConfiguration.name();
+  }
+
+  @Override
+  public int pass() {
+    return pass;
+  }
+
+  @Override
+  public void start(Registrar registrar) {
+    // pass 0 or 1 is bootstrap, pass 2 is for reals
+    if (pass < 2) {
+      logger = new Slf4jLogger();
+      registrar.register(this.pluginConfiguration.name(), this.pluginConfiguration.isDefaultLogger(), this);
+      pass = 2;
+    } else if (pass == 2 && registrar.world() != null) { // if this is a test there may not be a World
+      logger = registrar.world()
+              .actorFor(Logger.class, Definition.has(Slf4jLoggerActor.class, Definition.parameters(logger), logger));
+      registrar.register(this.pluginConfiguration.name(), this.pluginConfiguration.isDefaultLogger(), this);
+    }
+  }
+
+  @Override
+  public Plugin with(PluginConfiguration overrideConfiguration) {
+    if (overrideConfiguration == null) {
+      return this;
+    }
+    return new Slf4jLoggerPlugin(overrideConfiguration);
+  }
+
+  public static class Slf4jLoggerPluginConfiguration implements PluginConfiguration {
+    private boolean defaultLogger;
+    private String name;
+
+    public boolean isDefaultLogger() {
+      return defaultLogger;
+    }
+
+    @Override
+    public String name() {
+      return this.name;
+    }
+
+    @Override
+    public void build(Configuration configuration) {
+      configuration.with(defaultLogger().name("vlingo/actors"));
+    }
+
+    @Override
+    public void buildWith(Configuration configuration, PluginProperties properties) {
+      this.name = properties.name;
+      this.defaultLogger = properties.getBoolean("defaultLogger", true);
+    }
+
+    public Slf4jLoggerPluginConfiguration defaultLogger() {
+      this.defaultLogger = true;
+      return this;
+    }
+
+    public Slf4jLoggerPluginConfiguration name(final String name) {
+      this.name = name;
+      return this;
+    }
+  }
+}

--- a/src/main/java/io/vlingo/actors/plugin/logging/slf4j/Slf4jLoggerPlugin.java
+++ b/src/main/java/io/vlingo/actors/plugin/logging/slf4j/Slf4jLoggerPlugin.java
@@ -112,5 +112,9 @@ public class Slf4jLoggerPlugin extends AbstractPlugin implements Plugin, LoggerP
       this.name = name;
       return this;
     }
+
+    public static Slf4jLoggerPluginConfiguration define() {
+      return new Slf4jLoggerPluginConfiguration();
+    }
   }
 }

--- a/src/main/java/io/vlingo/actors/plugin/supervision/DefaultSupervisorOverride.java
+++ b/src/main/java/io/vlingo/actors/plugin/supervision/DefaultSupervisorOverride.java
@@ -39,7 +39,7 @@ public class DefaultSupervisorOverride extends Actor implements Supervisor {
 
   @Override
   public void inform(final Throwable throwable, final Supervised supervised) {
-    logger().log("DefaultSupervisorOverride: Failure of: " + supervised.address() + " because: " + throwable.getMessage() + " Action: Resuming.", throwable);
+    logger().error("DefaultSupervisorOverride: Failure of: " + supervised.address() + " because: " + throwable.getMessage() + " Action: Resuming.", throwable);
     supervised.resume();
   }
 

--- a/src/test/java/io/vlingo/actors/ActorStopTest.java
+++ b/src/test/java/io/vlingo/actors/ActorStopTest.java
@@ -23,7 +23,7 @@ public class ActorStopTest extends ActorsTest {
 
     final AccessSafely beforeStartCountAccess = results.beforeStartCountAccessCompletes(12);
     
-    world.defaultLogger().log("Test: testStopActors: starting actors");
+    world.defaultLogger().debug("Test: testStopActors: starting actors");
 
     final ChildCreatingStoppable[] stoppables = setUpActors(world, results);
 
@@ -34,7 +34,7 @@ public class ActorStopTest extends ActorsTest {
     final int beforeStartCount = beforeStartCountAccess.readFrom("value");
     assertEquals(12, beforeStartCount);
 
-    world.defaultLogger().log("Test: testStopActors: stopping actors");
+    world.defaultLogger().debug("Test: testStopActors: stopping actors");
 
     results.terminatingAccessCompletes(0).writeUsing("value", false);
 
@@ -47,8 +47,8 @@ public class ActorStopTest extends ActorsTest {
     final int stopCount = stopCountAccess.readFromExpecting("value", 12);
     assertEquals(12, stopCount);
 
-    world.defaultLogger().log("Test: testStopActors: stopped actors");
-    world.defaultLogger().log("Test: testStopActors: terminating world");
+    world.defaultLogger().debug("Test: testStopActors: stopped actors");
+    world.defaultLogger().debug("Test: testStopActors: terminating world");
 
     results.terminatingStopCountAccessCompletes(0);
 

--- a/src/test/java/io/vlingo/actors/ActorsTest.java
+++ b/src/test/java/io/vlingo/actors/ActorsTest.java
@@ -10,10 +10,10 @@ package io.vlingo.actors;
 import org.junit.After;
 import org.junit.Before;
 
-import io.vlingo.actors.plugin.logging.jdk.QuietHandler;
-import io.vlingo.actors.plugin.logging.jdk.JDKLoggerPlugin.JDKLoggerPluginConfiguration;
 import io.vlingo.actors.testkit.TestUntil;
 import io.vlingo.actors.testkit.TestWorld;
+
+import io.vlingo.actors.plugin.logging.slf4j.Slf4jLoggerPlugin;
 
 public abstract class ActorsTest {
   protected World world;
@@ -31,13 +31,11 @@ public abstract class ActorsTest {
     Configuration configuration =
             Configuration
               .define()
-              .with(JDKLoggerPluginConfiguration
+              .with(Slf4jLoggerPlugin
+                      .Slf4jLoggerPluginConfiguration
                       .define()
                       .defaultLogger()
-                      .name("vlingo/actors")
-                      .handlerClass(QuietHandler.class) // SWITCH TO DefaultHandler TO SEE LOGS
-                      .handlerName("vlingo-supervisors-test")
-                      .handlerLevel("ALL"));
+                      .name("vlingo/actors"));
 
       testWorld = TestWorld.start("test", configuration);
       world = testWorld.world();

--- a/src/test/java/io/vlingo/actors/ProxyGeneratorTest.java
+++ b/src/test/java/io/vlingo/actors/ProxyGeneratorTest.java
@@ -25,7 +25,7 @@ public class ProxyGeneratorTest {
 
     @Before
     public void setUp() throws Exception {
-        proxyGenerator = ProxyGenerator.forTest(false, Logger.testLogger());
+        proxyGenerator = ProxyGenerator.forTest(false, Logger.basicLogger());
     }
 
     @Test

--- a/src/test/java/io/vlingo/actors/plugin/logger/JDKLoggerTest.java
+++ b/src/test/java/io/vlingo/actors/plugin/logger/JDKLoggerTest.java
@@ -107,10 +107,10 @@ public class JDKLoggerTest extends ActorsTest {
     
     assertNotNull(logger);
     assertEquals("testRegistration", plugin.logger().name());
-    
-    logger.log("TEST:3 1");
-    logger.log("TEST:3 2");
-    logger.log("TEST:3 3");
+
+    logger.debug("TEST:3 1");
+    logger.debug("TEST:3 2");
+    logger.debug("TEST:3 3");
   }
   
   @Test
@@ -120,10 +120,6 @@ public class JDKLoggerTest extends ActorsTest {
     assertNotNull(logger);
     assertEquals("testStandardLogger", logger.name());
     
-    logger.log("TEST:4 1");
-    logger.log("TEST:4 2");
-    logger.log("TEST:4 3");
-
     logger.trace("TRACE message");
     logger.trace("TRACE message with parameters {0}", "1");
     logger.trace("TRACE message with exception", new Exception("test trace exception"));

--- a/src/test/java/io/vlingo/actors/plugin/logger/JDKLoggerTest.java
+++ b/src/test/java/io/vlingo/actors/plugin/logger/JDKLoggerTest.java
@@ -113,34 +113,6 @@ public class JDKLoggerTest extends ActorsTest {
     logger.debug("TEST:3 3");
   }
   
-  @Test
-  public void testStandardLogger() {
-    logger = LoggerProvider.standardLoggerProvider(world, "testStandardLogger").logger();
-    
-    assertNotNull(logger);
-    assertEquals("testStandardLogger", logger.name());
-    
-    logger.trace("TRACE message");
-    logger.trace("TRACE message with parameters {0}", "1");
-    logger.trace("TRACE message with exception", new Exception("test trace exception"));
-
-    logger.debug("DEBUG message");
-    logger.debug("DEBUG message with parameters {0}", "2");
-    logger.debug("DEBUG message with exception", new Exception("test debug exception"));
-
-    logger.info("INFO message");
-    logger.info("INFO message with parameters {0}", "3");
-    logger.info("INFO message with exception", new Exception("test info exception"));
-
-    logger.warn("WARN message");
-    logger.warn("WARN message with parameters {0}", "4");
-    logger.warn("WARN message with exception", new Exception("test warn exception"));
-
-    logger.error("ERROR message");
-    logger.error("ERROR message with parameters {0}", "4");
-    logger.error("ERROR message with exception", new Exception("test error exception"));
-  }
-  
   @After
   @Override
   public void tearDown() throws Exception {

--- a/src/test/java/io/vlingo/actors/plugin/logging/slf4j/Slf4jLoggerPluginTest.java
+++ b/src/test/java/io/vlingo/actors/plugin/logging/slf4j/Slf4jLoggerPluginTest.java
@@ -7,6 +7,7 @@
 
 package io.vlingo.actors.plugin.logging.slf4j;
 
+import io.vlingo.actors.ActorsTest;
 import org.junit.Test;
 
 import java.util.Properties;
@@ -22,7 +23,7 @@ import io.vlingo.actors.Registrar;
 import io.vlingo.actors.plugin.PluginProperties;
 import io.vlingo.actors.plugin.completes.MockRegistrar;
 
-public class Slf4jLoggerPluginTest {
+public class Slf4jLoggerPluginTest extends ActorsTest {
   private boolean registered;
 
   private final Registrar registrar = new MockRegistrar() {
@@ -31,6 +32,35 @@ public class Slf4jLoggerPluginTest {
       registered = true;
     }
   };
+
+
+  @Test
+  public void testStandardLogger() {
+    Logger logger = LoggerProvider.standardLoggerProvider(world, "testStandardLogger").logger();
+
+    assertNotNull(logger);
+    assertEquals("testStandardLogger", logger.name());
+
+    logger.trace("TRACE message");
+    logger.trace("TRACE message with parameters {0}", "1");
+    logger.trace("TRACE message with exception", new Exception("test trace exception"));
+
+    logger.debug("DEBUG message");
+    logger.debug("DEBUG message with parameters {0}", "2");
+    logger.debug("DEBUG message with exception", new Exception("test debug exception"));
+
+    logger.info("INFO message");
+    logger.info("INFO message with parameters {0}", "3");
+    logger.info("INFO message with exception", new Exception("test info exception"));
+
+    logger.warn("WARN message");
+    logger.warn("WARN message with parameters {0}", "4");
+    logger.warn("WARN message with exception", new Exception("test warn exception"));
+
+    logger.error("ERROR message");
+    logger.error("ERROR message with parameters {0}", "4");
+    logger.error("ERROR message with exception", new Exception("test error exception"));
+  }
 
   @Test
   public void testRegistration() {

--- a/src/test/java/io/vlingo/actors/plugin/logging/slf4j/Slf4jLoggerPluginTest.java
+++ b/src/test/java/io/vlingo/actors/plugin/logging/slf4j/Slf4jLoggerPluginTest.java
@@ -1,0 +1,55 @@
+// Copyright © 2012-2018 Vaughn Vernon. All rights reserved.
+//
+// This Source Code Form is subject to the terms of the
+// Mozilla Public License, v. 2.0. If a copy of the MPL
+// was not distributed with this file, You can obtain
+// one at https://mozilla.org/MPL/2.0/.
+
+package io.vlingo.actors.plugin.logging.slf4j;
+
+import org.junit.Test;
+
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import io.vlingo.actors.Configuration;
+import io.vlingo.actors.Logger;
+import io.vlingo.actors.LoggerProvider;
+import io.vlingo.actors.Registrar;
+import io.vlingo.actors.plugin.PluginProperties;
+import io.vlingo.actors.plugin.completes.MockRegistrar;
+
+public class Slf4jLoggerPluginTest {
+  private boolean registered;
+
+  private final Registrar registrar = new MockRegistrar() {
+    @Override
+    public void register(String name, boolean isDefault, LoggerProvider loggerProvider) {
+      registered = true;
+    }
+  };
+
+  @Test
+  public void testRegistration() {
+    final Configuration configuration = Configuration.define();
+    final Slf4jLoggerPlugin plugin = new Slf4jLoggerPlugin();
+    plugin.configuration().buildWith(configuration, new PluginProperties("slf4jTestRegistration", new Properties()));
+
+    plugin.start(registrar);
+
+    assertTrue(registered);
+
+    Logger logger = plugin.logger();
+
+    assertNotNull(logger);
+    assertEquals("slf4jTestRegistration", plugin.name());
+
+    logger.debug("TEST:3 1");
+    logger.debug("TEST:3 2");
+    logger.debug("TEST:3 3");
+  }
+
+}

--- a/src/test/java/io/vlingo/actors/plugin/mailbox/concurrentqueue/ExecutorDispatcherTest.java
+++ b/src/test/java/io/vlingo/actors/plugin/mailbox/concurrentqueue/ExecutorDispatcherTest.java
@@ -38,7 +38,7 @@ public class ExecutorDispatcherTest extends ActorsTest {
 
   @Test
   public void testClose() {
-    final TestResults testResults = new TestResults(3, true);
+    final TestResults testResults = new TestResults(3, false);
 
     final TestMailbox mailbox = new TestMailbox(testResults, world.defaultLogger());
 
@@ -71,7 +71,7 @@ public class ExecutorDispatcherTest extends ActorsTest {
 
   @Test
   public void testExecute() {
-    final TestResults testResults = new TestResults(Total, true);
+    final TestResults testResults = new TestResults(Total, false);
     
     final TestMailbox mailbox = new TestMailbox(testResults, world.defaultLogger());
 

--- a/src/test/java/io/vlingo/actors/plugin/mailbox/concurrentqueue/ExecutorDispatcherTest.java
+++ b/src/test/java/io/vlingo/actors/plugin/mailbox/concurrentqueue/ExecutorDispatcherTest.java
@@ -120,12 +120,12 @@ public class ExecutorDispatcherTest extends ActorsTest {
     public void run() {
       final Message message = receive();
       if (testResults.shouldLog) {
-        logger.log("TestMailbox: run: received: " + message);
+        logger.debug("TestMailbox: run: received: " + message);
       }
       if (message != null) {
         message.deliver();
         if (testResults.shouldLog) {
-          logger.log("TestMailbox: run: adding: " + testResults.getHighest());
+          logger.debug("TestMailbox: run: adding: " + testResults.getHighest());
         }
       }
     }
@@ -208,11 +208,11 @@ public class ExecutorDispatcherTest extends ActorsTest {
               .afterCompleting(happenings)
               .writingWith("results", (BiConsumer<Integer, Logger>) (count, logger) -> {
                 if (shouldLog) {
-                  logger.log("CountTakerActor: take: " + count);
+                  logger.debug("CountTakerActor: take: " + count);
                 }
                 if (count > highest.get()) {
                   if (shouldLog) {
-                    logger.log("CountTakerActor: take: " + count + " > " + highest.get());
+                    logger.debug("CountTakerActor: take: " + count + " > " + highest.get());
                   }
                   highest.set(count);
                 }

--- a/src/test/resources/vlingo-actors.properties
+++ b/src/test/resources/vlingo-actors.properties
@@ -33,27 +33,11 @@ plugin.queueMailbox.defaultMailbox = true
 plugin.queueMailbox.numberOfDispatchersFactor = 1.5
 plugin.queueMailbox.dispatcherThrottlingCount = 1
 
-plugin.name.jdkLogger = true
-plugin.jdkLogger.classname = io.vlingo.actors.plugin.logging.jdk.JDKLoggerPlugin
-plugin.jdkLogger.name = vlingo/actors(test)
-plugin.jdkLogger.defaultLogger = true
-plugin.jdkLogger.handler.classname = io.vlingo.actors.plugin.logging.jdk.DefaultHandler
-plugin.jdkLogger.handler.name = vlingo
-plugin.jdkLogger.handler.level = ALL
-
-# only enable the following when not testing or you will
-# have a big mess to clean up after every full test
-#plugin.name.jdkLogger = true
-#plugin.jdkLogger.classname = io.vlingo.actors.plugin.logging.jdk.JDKLoggerPlugin
-#plugin.jdkLogger.defaultLogger = true
-#plugin.jdkLogger.handler.classname = java.util.logging.FileHandler
-#plugin.jdkLogger.handler.name = vlingo
-#plugin.jdkLogger.handler.level = ALL
-#plugin.jdkLogger.filehandler.pattern = vlingo_actors.log
-#plugin.jdkLogger.filehandler.limit = 100000000
-#plugin.jdkLogger.filehandler.count = 3
-#plugin.jdkLogger.filehandler.append = false
-
+plugin.name.slf4jLogger = true
+plugin.slf4jLogger.classname = io.vlingo.actors.plugin.logging.slf4j.Slf4jLoggerPlugin
+plugin.slf4jLogger.name = vlingo/actors(test)
+plugin.slf4jLogger.defaultLogger = true
+        
 plugin.name.common_supervisors = true
 plugin.common_supervisors.classname = io.vlingo.actors.plugin.supervision.CommonSupervisorsPlugin
 plugin.common_supervisors.types =\


### PR DESCRIPTION
This PR adds a new logging plugin that relies on Slf4j logging library and allowing the end user to plug in the desired logging framework at deployment time.

Some important changes:
- I have increased the library version to **0.9.0**.
- The Slf4j is now the default  logging plugin. If a project has configured the `JDKLoggerPlugin`, it will be used instead of Slf4j. 
- I have added a new dependency: `org.slf4j:slf4j-api:1.7.26`. This library only has the APIs and no logging implementation. Projects, using vlingo-actors, will have to add a new dependency for the desired [logging framework](https://www.slf4j.org/manual.html#swapping). For example the lingo-actors tests are using `ch.qos.logback:logback-classic:1.0.13`