### PR TITLE
add testInstance to Slf4jLoggerPlugin to match api of removed JDKLogger

### DIFF
--- a/src/main/java/io/vlingo/actors/plugin/logging/slf4j/Slf4jLoggerPlugin.java
+++ b/src/main/java/io/vlingo/actors/plugin/logging/slf4j/Slf4jLoggerPlugin.java
@@ -32,6 +32,10 @@ public class Slf4jLoggerPlugin extends AbstractPlugin implements Plugin, LoggerP
     return new Slf4jLogger(loggerConfiguration.name());
   }
 
+  public static Logger testInstance() {
+    return basicInstance();
+  }
+
   public static LoggerProvider registerStandardLogger(final String name, final Registrar registrar) {
     final Slf4jLoggerPlugin plugin = new Slf4jLoggerPlugin();
     final Slf4jLoggerPluginConfiguration pluginConfiguration = (Slf4jLoggerPluginConfiguration) plugin.configuration();


### PR DESCRIPTION
make it easy for people dealing with the removal of the JDKLogger class to know which method to use instead of JDKLogger.testInstance().  The new static method in Slf4jLoggerPlugin mimics the old one.