### PR TITLE
Replaces CopyOnWriteArrayList with TreePVector from pcollections

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,11 @@
       <version>1.0.2</version>
     </dependency>
     <dependency>
+      <groupId>org.pcollections</groupId>
+      <artifactId>pcollections</artifactId>
+      <version>3.1.0</version>
+    </dependency>
+    <dependency>
       <groupId>io.vlingo</groupId>
       <artifactId>vlingo-common</artifactId>
       <version>0.9.1-RC2</version>

--- a/src/main/java/io/vlingo/actors/Environment.java
+++ b/src/main/java/io/vlingo/actors/Environment.java
@@ -7,15 +7,16 @@
 
 package io.vlingo.actors;
 
+import org.pcollections.PVector;
+import org.pcollections.TreePVector;
+
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class Environment {
   final Address address;
-  final List<Actor> children;
+  PVector<Actor> children;
   Address completesEventuallyAddress;
   final Definition definition;
   final FailureMark failureMark;
@@ -54,7 +55,7 @@ public class Environment {
     this.maybeSupervisor = maybeSupervisor;
     this.failureMark = new FailureMark();
     this.logger = logger;
-    this.children = new CopyOnWriteArrayList<Actor>();
+    this.children = TreePVector.empty();
     this.proxyCache = new HashMap<>();
 //    this.stowage = new Stowage();
     this.stowageOverrides = null;
@@ -65,7 +66,7 @@ public class Environment {
   }
 
   void addChild(final Actor child) {
-    children.add(child);
+    children = children.plus(child);
   }
 
   CompletesEventually completesEventually(final ResultReturns result) {
@@ -128,6 +129,6 @@ public class Environment {
   private void stopChildren() {
     // TODO: re-implement as: children.forEach(child -> selfAs(Stoppable.class).stop());
     children.forEach(child -> child.stop());
-    children.clear();
+    children = TreePVector.empty();
   }
 }


### PR DESCRIPTION
TreePVector achieves the same concurrency goals as CopyOnWriteArrayList but yields better `add` performance and less work for the garbage collector.

https://javadoc.io/static/org.pcollections/pcollections/3.1.0/org/pcollections/TreePVector.html