### PR TITLE
Simplify ActorInstantiator

### DIFF
--- a/src/main/java/io/vlingo/actors/ActorInstantiator.java
+++ b/src/main/java/io/vlingo/actors/ActorInstantiator.java
@@ -7,25 +7,11 @@
 
 package io.vlingo.actors;
 
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
+@FunctionalInterface
 public interface ActorInstantiator<A extends Actor> {
   A instantiate();
-  Class<A> type();
 
-  default void set(final String name, final Object value) { }
-
-  static class Registry {
-    private static final Map<Class<?>, ActorInstantiator<?>> instantiators = new ConcurrentHashMap<>();
-
-    @SuppressWarnings("unchecked")
-    public static <A extends Actor> ActorInstantiator<A> instantiatorFor(final Class<?> type) {
-      return (ActorInstantiator<A>) instantiators.get(type);
-    }
-
-    public static void register(final Class<?> type, ActorInstantiator<?> instantiator) {
-      instantiators.put(type, instantiator);
-    }
-  }
+  default Class<A> type() {
+    return null;
+  };
 }

--- a/src/main/java/io/vlingo/actors/CompletesEventually.java
+++ b/src/main/java/io/vlingo/actors/CompletesEventually.java
@@ -8,8 +8,6 @@
 package io.vlingo.actors;
 
 public interface CompletesEventually extends Stoppable {
-  static ActorInstantiator<CompletesEventuallyActor> Instantiator = new CompletesEventuallyInstantiator();
-
   Address address();
   void with(final Object outcome);
   @Override
@@ -18,16 +16,4 @@ public interface CompletesEventually extends Stoppable {
   default boolean isStopped() { return false; }
   @Override
   default void stop() { }
-
-  static class CompletesEventuallyInstantiator implements ActorInstantiator<CompletesEventuallyActor> {
-    @Override
-    public CompletesEventuallyActor instantiate() {
-      return new CompletesEventuallyActor();
-    }
-
-    @Override
-    public Class<CompletesEventuallyActor> type() {
-      return CompletesEventuallyActor.class;
-    }
-  }
 }

--- a/src/main/java/io/vlingo/actors/DeadLettersActor.java
+++ b/src/main/java/io/vlingo/actors/DeadLettersActor.java
@@ -14,9 +14,7 @@ public class DeadLettersActor extends Actor implements DeadLetters {
   private final List<DeadLettersListener> listeners;
 
   public DeadLettersActor() {
-    this.listeners = new ArrayList<DeadLettersListener>();
-    
-    stage().world().setDeadLetters(selfAs(DeadLetters.class));
+    this.listeners = new ArrayList<>();
   }
 
   public void failedDelivery(final DeadLetter deadLetter) {
@@ -35,6 +33,13 @@ public class DeadLettersActor extends Actor implements DeadLetters {
   @Override
   public void registerListener(final DeadLettersListener listener) {
     listeners.add(listener);
+  }
+
+  @Override
+  protected void beforeStart() {
+    super.beforeStart();
+
+    stage().world().setDeadLetters(selfAs(DeadLetters.class));
   }
 
   @Override

--- a/src/main/java/io/vlingo/actors/DirectoryScannerActor.java
+++ b/src/main/java/io/vlingo/actors/DirectoryScannerActor.java
@@ -7,9 +7,9 @@
 
 package io.vlingo.actors;
 
-import java.util.Optional;
-
 import io.vlingo.common.Completes;
+
+import java.util.Optional;
 
 public class DirectoryScannerActor extends Actor implements DirectoryScanner {
   private final Directory directory;
@@ -56,23 +56,5 @@ public class DirectoryScannerActor extends Actor implements DirectoryScanner {
       logger().error("Error providing protocol: " + protocol.getName() + " for actor with address: " + address, e);
     }
     return null;
-  }
-
-  public static class DirectoryScannerInstantiator implements ActorInstantiator<DirectoryScannerActor> {
-    private final Directory directory;
-
-    public DirectoryScannerInstantiator(final Directory directory) {
-      this.directory = directory;
-    }
-
-    @Override
-    public DirectoryScannerActor instantiate() {
-      return new DirectoryScannerActor(directory);
-    }
-
-    @Override
-    public Class<DirectoryScannerActor> type() {
-      return DirectoryScannerActor.class;
-    }
   }
 }

--- a/src/main/java/io/vlingo/actors/PrivateRootActor.java
+++ b/src/main/java/io/vlingo/actors/PrivateRootActor.java
@@ -26,29 +26,31 @@ public class PrivateRootActor extends Actor implements Stoppable, Supervisor {
             }
           };
 
-  public PrivateRootActor() {
-    stage().world().setPrivateRoot(selfAs(Stoppable.class));
+    @Override
+    protected void beforeStart() {
+        super.beforeStart();
+        stage().world().setPrivateRoot(selfAs(Stoppable.class));
 
-    stage().actorProtocolFor(
-              NoProtocol.class,
-              Definition.has(PublicRootActor.class, Definition.NoParameters, World.PUBLIC_ROOT_NAME),
-              this,
-              stage().world().addressFactory().from(World.PUBLIC_ROOT_ID, World.PUBLIC_ROOT_NAME),
-              null,
-              null,
-              logger());
+        stage().actorProtocolFor(
+                NoProtocol.class,
+                Definition.has(PublicRootActor.class, PublicRootActor::new, World.PUBLIC_ROOT_NAME),
+                this,
+                stage().world().addressFactory().from(World.PUBLIC_ROOT_ID, World.PUBLIC_ROOT_NAME),
+                null,
+                null,
+                logger());
 
-    stage().actorProtocolFor(
-              DeadLetters.class,
-              Definition.has(DeadLettersActor.class, Definition.NoParameters, World.DEADLETTERS_NAME),
-              this,
-              stage().world().addressFactory().from(World.DEADLETTERS_ID, World.DEADLETTERS_NAME),
-              null,
-              null,
-              logger());
-  }
+        stage().actorProtocolFor(
+                DeadLetters.class,
+                Definition.has(DeadLettersActor.class, DeadLettersActor::new, World.DEADLETTERS_NAME),
+                this,
+                stage().world().addressFactory().from(World.DEADLETTERS_ID, World.DEADLETTERS_NAME),
+                null,
+                null,
+                logger());
+    }
 
-  @Override
+    @Override
   protected void afterStop() {
     stage().world().setPrivateRoot(null);
     super.afterStop();

--- a/src/main/java/io/vlingo/actors/PublicRootActor.java
+++ b/src/main/java/io/vlingo/actors/PublicRootActor.java
@@ -28,13 +28,18 @@ public class PublicRootActor extends Actor implements Stoppable, Supervisor {
           };
 
   public PublicRootActor() {
-    this.self = selfAs(Supervisor.class);
-
-    stage().world().setDefaultParent(this);
-    stage().world().setPublicRoot(selfAs(Stoppable.class));
+      this.self = selfAs(Supervisor.class);
   }
 
-  @Override
+    @Override
+    protected void beforeStart() {
+        super.beforeStart();
+
+        stage().world().setDefaultParent(this);
+        stage().world().setPublicRoot(selfAs(Stoppable.class));
+    }
+
+    @Override
   protected void afterStop() {
     stage().world().setDefaultParent(null);
     stage().world().setPublicRoot(null);

--- a/src/main/java/io/vlingo/actors/Stage.java
+++ b/src/main/java/io/vlingo/actors/Stage.java
@@ -7,17 +7,16 @@
 
 package io.vlingo.actors;
 
+import io.vlingo.actors.plugin.mailbox.testkit.TestMailbox;
+import io.vlingo.actors.testkit.TestActor;
+import io.vlingo.common.Completes;
+import io.vlingo.common.Scheduler;
+
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
-
-import io.vlingo.actors.DirectoryScannerActor.DirectoryScannerInstantiator;
-import io.vlingo.actors.plugin.mailbox.testkit.TestMailbox;
-import io.vlingo.actors.testkit.TestActor;
-import io.vlingo.common.Completes;
-import io.vlingo.common.Scheduler;
 
 public class Stage implements Stoppable {
   private final AddressFactory addressFactory;
@@ -556,7 +555,7 @@ public class Stage implements Stoppable {
    * Start the directory scan process in search for a given Actor instance. (INTERNAL ONLY)
    */
   void startDirectoryScanner() {
-    this.directoryScanner = actorFor(DirectoryScanner.class, Definition.has(DirectoryScannerActor.class, new DirectoryScannerInstantiator(directory)));
+    this.directoryScanner = actorFor(DirectoryScanner.class, Definition.has(DirectoryScannerActor.class, () -> new DirectoryScannerActor(directory)));
   }
 
   /**

--- a/src/main/java/io/vlingo/actors/World.java
+++ b/src/main/java/io/vlingo/actors/World.java
@@ -7,13 +7,13 @@
 
 package io.vlingo.actors;
 
-import java.lang.reflect.Constructor;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-
 import io.vlingo.actors.plugin.completes.DefaultCompletesEventuallyProviderKeeper;
 import io.vlingo.actors.plugin.logging.DefaultLoggerProviderKeeper;
 import io.vlingo.actors.plugin.mailbox.DefaultMailboxProviderKeeper;
+
+import java.lang.reflect.Constructor;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * The {@code World} of the actor runtime through which all Stage and Actor instances are created and run.
@@ -650,7 +650,7 @@ public final class World implements Registrar {
   private void startRootFor(final Stage stage, final Logger logger) {
     stage.actorProtocolFor(
         Stoppable.class,
-        Definition.has(PrivateRootActor.class, Definition.NoParameters, PRIVATE_ROOT_NAME),
+        Definition.has(PrivateRootActor.class, PrivateRootActor::new, PRIVATE_ROOT_NAME),
         null,
         addressFactory.from(PRIVATE_ROOT_ID, PRIVATE_ROOT_NAME),
         null,

--- a/src/main/java/io/vlingo/actors/plugin/PluginFactory.java
+++ b/src/main/java/io/vlingo/actors/plugin/PluginFactory.java
@@ -1,0 +1,6 @@
+package io.vlingo.actors.plugin;
+
+@FunctionalInterface
+public interface PluginFactory {
+    Plugin build();
+}

--- a/src/main/java/io/vlingo/actors/plugin/PluginLoader.java
+++ b/src/main/java/io/vlingo/actors/plugin/PluginLoader.java
@@ -7,15 +7,9 @@
 
 package io.vlingo.actors.plugin;
 
-import java.util.Collection;
-import java.util.Enumeration;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
-
 import io.vlingo.actors.Configuration;
+
+import java.util.*;
 
 public class PluginLoader {
   private static final String pluginNamePrefix = "plugin.name.";
@@ -36,7 +30,7 @@ public class PluginLoader {
   }
 
   private Set<String> findEnabledPlugins(final Properties properties) {
-    final Set<String> enabledPlugins = new HashSet<String>();
+    final Set<String> enabledPlugins = new HashSet<>();
 
     for (Enumeration<?> e = properties.keys(); e.hasMoreElements(); ) {
       final String key = (String) e.nextElement();

--- a/src/main/java/io/vlingo/actors/plugin/completes/CompletesEventuallyPool.java
+++ b/src/main/java/io/vlingo/actors/plugin/completes/CompletesEventuallyPool.java
@@ -7,16 +7,9 @@
 
 package io.vlingo.actors.plugin.completes;
 
-import java.util.concurrent.atomic.AtomicLong;
+import io.vlingo.actors.*;
 
-import io.vlingo.actors.Address;
-import io.vlingo.actors.CompletesEventually;
-import io.vlingo.actors.CompletesEventuallyActor;
-import io.vlingo.actors.CompletesEventuallyProvider;
-import io.vlingo.actors.Definition;
-import io.vlingo.actors.PooledCompletes;
-import io.vlingo.actors.Returns;
-import io.vlingo.actors.Stage;
+import java.util.concurrent.atomic.AtomicLong;
 
 public class CompletesEventuallyPool implements CompletesEventuallyProvider {
   private final AtomicLong completesEventuallyId;
@@ -54,7 +47,7 @@ public class CompletesEventuallyPool implements CompletesEventuallyProvider {
                       CompletesEventually.class,
                       Definition.has(
                               CompletesEventuallyActor.class,
-                              CompletesEventually.Instantiator,
+                              CompletesEventuallyActor::new,
                               mailboxName,
                               "completes-eventually-" + (idx + 1)));
     }

--- a/src/main/java/io/vlingo/actors/plugin/logging/slf4j/Slf4jLoggerActor.java
+++ b/src/main/java/io/vlingo/actors/plugin/logging/slf4j/Slf4jLoggerActor.java
@@ -8,7 +8,6 @@
 package io.vlingo.actors.plugin.logging.slf4j;
 
 import io.vlingo.actors.Actor;
-import io.vlingo.actors.ActorInstantiator;
 import io.vlingo.actors.Logger;
 
 public class Slf4jLoggerActor extends Actor implements Logger {
@@ -112,23 +111,5 @@ public class Slf4jLoggerActor extends Actor implements Logger {
   @Override
   public void error(String message, Throwable throwable) {
     this.logger.error(message, throwable);
-  }
-
-  public static class Slf4jLoggerInstantiator implements ActorInstantiator<Slf4jLoggerActor> {
-    private final Logger logger;
-
-    public Slf4jLoggerInstantiator(final Logger logger) {
-      this.logger = logger;
-    }
-
-    @Override
-    public Slf4jLoggerActor instantiate() {
-      return new Slf4jLoggerActor(logger);
-    }
-
-    @Override
-    public Class<Slf4jLoggerActor> type() {
-      return Slf4jLoggerActor.class;
-    }
   }
 }

--- a/src/main/java/io/vlingo/actors/plugin/logging/slf4j/Slf4jLoggerPlugin.java
+++ b/src/main/java/io/vlingo/actors/plugin/logging/slf4j/Slf4jLoggerPlugin.java
@@ -6,18 +6,13 @@
 // one at https://mozilla.org/MPL/2.0/.
 package io.vlingo.actors.plugin.logging.slf4j;
 
-import java.util.Properties;
-
-import io.vlingo.actors.Configuration;
-import io.vlingo.actors.Definition;
-import io.vlingo.actors.Logger;
-import io.vlingo.actors.LoggerProvider;
-import io.vlingo.actors.Registrar;
+import io.vlingo.actors.*;
 import io.vlingo.actors.plugin.AbstractPlugin;
 import io.vlingo.actors.plugin.Plugin;
 import io.vlingo.actors.plugin.PluginConfiguration;
 import io.vlingo.actors.plugin.PluginProperties;
-import io.vlingo.actors.plugin.logging.slf4j.Slf4jLoggerActor.Slf4jLoggerInstantiator;
+
+import java.util.Properties;
 
 public class Slf4jLoggerPlugin extends AbstractPlugin implements Plugin, LoggerProvider {
   private final Slf4jLoggerPluginConfiguration pluginConfiguration;
@@ -87,7 +82,7 @@ public class Slf4jLoggerPlugin extends AbstractPlugin implements Plugin, LoggerP
       pass = 2;
     } else if (pass == 2 && registrar.world() != null) { // if this is a test there may not be a World
       logger = registrar.world()
-              .actorFor(Logger.class, Definition.has(Slf4jLoggerActor.class, new Slf4jLoggerInstantiator(logger), logger));
+              .actorFor(Logger.class, Definition.has(Slf4jLoggerActor.class, () -> new Slf4jLoggerActor(logger), logger));
       registrar.register(this.pluginConfiguration.name(), this.pluginConfiguration.isDefaultLogger(), this);
     }
   }

--- a/src/main/resources/vlingo-reflection
+++ b/src/main/resources/vlingo-reflection
@@ -1,0 +1,5 @@
+io.vlingo.actors.plugin.supervision.DefaultSupervisorOverride
+io.vlingo.actors.CompletesEventually__Proxy
+io.vlingo.actors.Logger__Proxy
+io.vlingo.actors.DirectoryScanner
+io.vlingo.actors.DirectoryScanner__Proxy


### PR DESCRIPTION
* Remove what seems unused classes (ActorInstantiator.Registry)
* Because ActorInstantiator.type() is unused, mark it as default and return null so it doesn't break the current contract.
* PrivateRootActor, PublicRootActor and DeadletterActor now uses instantiators.
* Default plugins do not use reflection now.
* Use beforeStart hooks to bind internal actors, instead of the constructor.
* Added vlingo-reflection so the compiler plugin now generates the required reflection.json