### PR TITLE
Address already registered

### DIFF
--- a/src/main/java/io/vlingo/actors/ActorProxyBase.java
+++ b/src/main/java/io/vlingo/actors/ActorProxyBase.java
@@ -21,7 +21,7 @@ public abstract class ActorProxyBase<T> implements Externalizable {
     if (arg instanceof ActorProxyBase) {
       @SuppressWarnings("unchecked")
       final ActorProxyBase<T> base = (ActorProxyBase<T>) arg;
-      return stage.lookupOrStart(base.protocol,
+      return stage.lookupOrStartThunk(base.protocol,
           Definition.from(stage, base.definition, stage.world().defaultLogger()),
           base.address);
     }

--- a/src/main/java/io/vlingo/actors/ActorProxyBase.java
+++ b/src/main/java/io/vlingo/actors/ActorProxyBase.java
@@ -1,6 +1,5 @@
 package io.vlingo.actors;
 
-import com.sun.deploy.security.BadCertificateDialog;
 import io.vlingo.actors.Definition.SerializationProxy;
 
 import java.io.Externalizable;

--- a/src/main/java/io/vlingo/actors/ActorProxyBase.java
+++ b/src/main/java/io/vlingo/actors/ActorProxyBase.java
@@ -1,5 +1,6 @@
 package io.vlingo.actors;
 
+import com.sun.deploy.security.BadCertificateDialog;
 import io.vlingo.actors.Definition.SerializationProxy;
 
 import java.io.Externalizable;
@@ -20,16 +21,10 @@ public abstract class ActorProxyBase<T> implements Externalizable {
   public static <T> T thunk(Stage stage, T arg) {
     if (arg instanceof ActorProxyBase) {
       @SuppressWarnings("unchecked")
-      final ActorProxyBase<T> base = (ActorProxyBase<T>)arg;
-      final Actor argActor = stage.directory.actorOf(base.address);
-      if (argActor == null) {
-        return stage.actorThunkFor(base.protocol,
-            Definition.from(stage, base.definition, stage.world().defaultLogger()),
-            base.address);
-      }
-      else {
-        return stage.actorProxyFor(base.protocol, argActor, argActor.lifeCycle.environment.mailbox);
-      }
+      final ActorProxyBase<T> base = (ActorProxyBase<T>) arg;
+      return stage.lookupOrStart(base.protocol,
+          Definition.from(stage, base.definition, stage.world().defaultLogger()),
+          base.address);
     }
     return arg;
   }

--- a/src/main/java/io/vlingo/actors/Directory.java
+++ b/src/main/java/io/vlingo/actors/Directory.java
@@ -79,7 +79,7 @@ final class Directory {
 
   void register(final Address address, final Actor actor) {
     if (isRegistered(address)) {
-      throw new IllegalArgumentException("The actor address is already registered: " + address);
+      throw new ActorAddressAlreadyRegistered(actor, address);
     }
     this.maps[mapIndex(address)].put(address, actor);
   }
@@ -115,5 +115,14 @@ final class Directory {
 
   private int mapIndex(final Address address) {
     return Math.abs(address.hashCode() % maps.length);
+  }
+
+
+  public static final class ActorAddressAlreadyRegistered extends IllegalArgumentException {
+    public ActorAddressAlreadyRegistered(Actor actor, Address address) {
+      super(String.format("Failed to register Actor of type %s. Address is already registered: %s",
+          actor.getClass(),
+          address));
+    }
   }
 }

--- a/src/main/java/io/vlingo/actors/Directory.java
+++ b/src/main/java/io/vlingo/actors/Directory.java
@@ -79,7 +79,7 @@ final class Directory {
 
   void register(final Address address, final Actor actor) {
     if (isRegistered(address)) {
-      throw new ActorAddressAlreadyRegistered(actor, address);
+      throw new ActorAddressAlreadyRegistered(actor.getClass(), address);
     }
     this.maps[mapIndex(address)].put(address, actor);
   }
@@ -119,9 +119,9 @@ final class Directory {
 
 
   public static final class ActorAddressAlreadyRegistered extends IllegalArgumentException {
-    public ActorAddressAlreadyRegistered(Actor actor, Address address) {
+    public ActorAddressAlreadyRegistered(Class<?> type, Address address) {
       super(String.format("Failed to register Actor of type %s. Address is already registered: %s",
-          actor.getClass(),
+          type,
           address));
     }
   }

--- a/src/main/java/io/vlingo/actors/Stage.java
+++ b/src/main/java/io/vlingo/actors/Stage.java
@@ -725,7 +725,7 @@ public class Stage implements Stoppable {
       return actor;
     }
     try {
-      return createRawActor(definition, null, address, null, null, world.defaultLogger());
+      return createRawActor(definition, definition.parentOr(world.defaultParent()), address, null, definition.supervisor(), world.defaultLogger());
     } catch (Directory.ActorAddressAlreadyRegistered ignored) {
       return rawLookupOrStart(definition, address);
     }

--- a/src/main/java/io/vlingo/actors/Stage.java
+++ b/src/main/java/io/vlingo/actors/Stage.java
@@ -670,18 +670,15 @@ public class Stage implements Stoppable {
    * @param maybeMailbox the possible Mailbox of the Actor to create
    * @param maybeSupervisor the possible Supervisor of the Actor to create
    * @param logger the Logger of the Actor to create
-   * @param <T> the protocol type
    * @return Actor
-   * @throws Exception thrown if there is a problem with Actor creation
    */
-  private <T> Actor createRawActor(
+  private Actor createRawActor(
           final Definition definition,
           final Actor parent,
           final Address maybeAddress,
           final Mailbox maybeMailbox,
           final Supervisor maybeSupervisor,
-          final Logger logger)
-  throws Exception {
+          final Logger logger) {
 
     if (isStopped()) {
       throw new IllegalStateException("Actor stage has been stopped.");

--- a/src/main/java/io/vlingo/actors/Stage.java
+++ b/src/main/java/io/vlingo/actors/Stage.java
@@ -452,7 +452,11 @@ public class Stage implements Stoppable {
       final Actor actor = createRawActor(definition, parent, maybeAddress, maybeMailbox, maybeSupervisor, logger);
       final T protocolActor = actorProxyFor(protocol, actor, actor.lifeCycle.environment.mailbox);
       return new ActorProtocolActor<T>(actor, protocolActor);
-    } catch (Exception e) {
+    }
+    catch (Directory.ActorAddressAlreadyRegistered e) {
+      throw e;
+    }
+    catch (Exception e) {
       world.defaultLogger().error("vlingo/actors: FAILED: " + e.getMessage(), e);
       return null;
     }
@@ -671,7 +675,7 @@ public class Stage implements Stoppable {
             maybeAddress : this.addressFactory().uniqueWith(definition.actorName());
 
     if (directory.isRegistered(address)) {
-      throw new IllegalStateException("Address already exists: " + address);
+      throw new Directory.ActorAddressAlreadyRegistered(definition.type(), address);
     }
 
     final Mailbox mailbox = maybeMailbox != null ?

--- a/src/main/java/io/vlingo/actors/Stage.java
+++ b/src/main/java/io/vlingo/actors/Stage.java
@@ -122,23 +122,6 @@ public class Stage implements Stoppable {
     return actor.protocolActor();
   }
 
-  public <T> T actorThunkFor(
-      final Class<T> protocol,
-      final Definition definition,
-      final Address address) {
-    final Mailbox actorMailbox = this.allocateMailbox(definition, address, null);
-    final ActorProtocolActor<T> actor =
-        actorProtocolFor(
-            protocol,
-            definition,
-            definition.parentOr(world.defaultParent()),
-            address,
-            actorMailbox,
-            definition.supervisor(),
-            definition.loggerOr(world.defaultLogger()));
-    return actor.protocolActor();
-  }
-
   /**
    * Answers the {@code T} protocol of the newly created {@code Actor} that implements the {@code protocol} and
    * that will be assigned the specific {@code logger}.

--- a/src/test/java/io/vlingo/actors/StageTest.java
+++ b/src/test/java/io/vlingo/actors/StageTest.java
@@ -7,11 +7,6 @@
 
 package io.vlingo.actors;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
-
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Test;
@@ -21,6 +16,8 @@ import io.vlingo.actors.WorldTest.SimpleActor;
 import io.vlingo.actors.WorldTest.TestResults;
 import io.vlingo.actors.plugin.mailbox.testkit.TestMailbox;
 import io.vlingo.actors.testkit.AccessSafely;
+
+import static org.junit.Assert.*;
 
 public class StageTest extends ActorsTest {
   @Test
@@ -194,6 +191,36 @@ public class StageTest extends ActorsTest {
   public void testThatProtocolsAreNotInterfaces() {
     world.stage().actorFor(new Class[] { NoProtocol.class, ParentInterfaceActor.class }, ParentInterfaceActor.class);
   }
+
+  @Test
+  public void testSingleThreadRawLookupOrStartFindsActorPreviouslyStartedWithActorFor() {
+    Address address = world.addressFactory().unique();
+    final Definition definition = Definition.has(ParentInterfaceActor.class,
+        ParentInterfaceActor::new);
+    world.stage().actorFor(NoProtocol.class, definition, address);
+    Actor existing = world.stage().rawLookupOrStart(definition, address);
+    assertSame(address, existing.address());
+  }
+
+  @Test
+  public void testSingleThreadActorLookupOrStartFindsActorPreviouslyStartedWithActorFor() {
+    Address address = world.addressFactory().unique();
+    final Definition definition = Definition.has(ParentInterfaceActor.class,
+        ParentInterfaceActor::new);
+    world.stage().actorFor(NoProtocol.class, definition, address);
+    Actor existing = world.stage().actorLookupOrStart(definition, address);
+    assertSame(address, existing.address());
+  }
+
+  @Test
+  public void testSingleThreadLookupOrStartFindsActorPreviouslyStartedWithActorFor() {
+    Address address = world.addressFactory().unique();
+    final Definition definition = Definition.has(ParentInterfaceActor.class,
+        ParentInterfaceActor::new);
+    world.stage().actorFor(NoProtocol.class, definition, address);
+    assertNotNull(world.stage().lookupOrStart(NoProtocol.class, definition, address));
+  }
+
 
   public static class ParentInterfaceActor extends Actor implements NoProtocol {
     public static ThreadLocal<ParentInterfaceActor> parent = new ThreadLocal<>();

--- a/src/test/java/io/vlingo/actors/StageTest.java
+++ b/src/test/java/io/vlingo/actors/StageTest.java
@@ -7,15 +7,20 @@
 
 package io.vlingo.actors;
 
-import java.util.concurrent.atomic.AtomicInteger;
-
-import org.junit.Test;
-
 import io.vlingo.actors.WorldTest.Simple;
 import io.vlingo.actors.WorldTest.SimpleActor;
 import io.vlingo.actors.WorldTest.TestResults;
 import io.vlingo.actors.plugin.mailbox.testkit.TestMailbox;
 import io.vlingo.actors.testkit.AccessSafely;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.junit.Assert.*;
 
@@ -203,6 +208,16 @@ public class StageTest extends ActorsTest {
   }
 
   @Test
+  public void testSingleThreadRawLookupOrStartFindsActorPreviouslyStartedWithRawLookupOrStart() {
+    Address address = world.addressFactory().unique();
+    final Definition definition = Definition.has(ParentInterfaceActor.class,
+        ParentInterfaceActor::new);
+    Actor started = world.stage().rawLookupOrStart(definition, address);
+    Actor found = world.stage().rawLookupOrStart(definition, address);
+    assertSame(started, found);
+  }
+
+  @Test
   public void testSingleThreadActorLookupOrStartFindsActorPreviouslyStartedWithActorFor() {
     Address address = world.addressFactory().unique();
     final Definition definition = Definition.has(ParentInterfaceActor.class,
@@ -213,12 +228,96 @@ public class StageTest extends ActorsTest {
   }
 
   @Test
+  public void testSingleThreadActorLookupOrStartFindsActorPreviouslyStartedWithActorLookupOrStart() {
+    Address address = world.addressFactory().unique();
+    final Definition definition = Definition.has(ParentInterfaceActor.class,
+        ParentInterfaceActor::new);
+    Actor started = world.stage().actorLookupOrStart(definition, address);
+    Actor found = world.stage().actorLookupOrStart(definition, address);
+    assertSame(started, found);
+  }
+
+  @Test
   public void testSingleThreadLookupOrStartFindsActorPreviouslyStartedWithActorFor() {
     Address address = world.addressFactory().unique();
     final Definition definition = Definition.has(ParentInterfaceActor.class,
         ParentInterfaceActor::new);
     world.stage().actorFor(NoProtocol.class, definition, address);
     assertNotNull(world.stage().lookupOrStart(NoProtocol.class, definition, address));
+  }
+
+  @Test
+  public void testSingleThreadLookupOrStartFindsActorPreviouslyStartedWithLookupOrStart() {
+    Address address = world.addressFactory().unique();
+    final Definition definition = Definition.has(ParentInterfaceActor.class,
+        ParentInterfaceActor::new);
+    assertNotNull(world.stage().lookupOrStart(NoProtocol.class, definition, address));
+    assertNotNull(world.stage().lookupOrStart(NoProtocol.class, definition, address));
+  }
+
+  private static final ExecutorService exec = Executors.newFixedThreadPool(32);
+
+  @Test
+  public void testMultiThreadRawLookupOrStartFindsActorPreviouslyStartedWIthRawLookupOrStart() {
+    final int size = 1000;
+
+    List<Address> addresses = IntStream.range(0, size)
+        .mapToObj((ignored) -> world.addressFactory().unique())
+        .collect(Collectors.toList());
+
+    CompletionService<Actor> completionService =
+        new ExecutorCompletionService<>(exec);
+
+    final Definition definition = Definition.has(ParentInterfaceActor.class,
+        ParentInterfaceActor::new);
+
+    multithreadedLookupOrStartTest(index ->
+            completionService.submit(() ->
+                world.stage()
+                    .rawLookupOrStart(definition, addresses.get(index)))
+        , size);
+  }
+
+  @Test
+  public void testMultiThreadActorLookupOrStartFindsActorPreviouslyStartedWIthActorLookupOrStart() {
+    final int size = 1000;
+
+    List<Address> addresses = IntStream.range(0, size)
+        .mapToObj((ignored) -> world.addressFactory().unique())
+        .collect(Collectors.toList());
+
+    CompletionService<Actor> completionService =
+        new ExecutorCompletionService<>(exec);
+
+    final Definition definition = Definition.has(ParentInterfaceActor.class,
+        ParentInterfaceActor::new);
+
+    multithreadedLookupOrStartTest(index ->
+            completionService.submit(() ->
+                world.stage()
+                    .actorLookupOrStart(definition, addresses.get(index)))
+        , size);
+  }
+
+  private void multithreadedLookupOrStartTest(final Function<Integer, Future<Actor>> work, final int size) {
+    List<Future<Actor>> futures = IntStream.range(0, size)
+        .flatMap(i -> IntStream.of(i, i))
+        .mapToObj(work::apply)
+        .collect(Collectors.toList());
+
+    List<Actor> results = new ArrayList<>(futures.size());
+    for (Future<Actor> future : futures) {
+      try {
+        final Actor actor = future.get();
+        if (!results.isEmpty() && results.size() % 2 != 0) {
+          final Actor expected = results.get(results.size() - 1);
+          assertSame(expected.address(), actor.address());
+        }
+        results.add(actor);
+      } catch (InterruptedException | ExecutionException e) {
+        e.printStackTrace();
+      }
+    }
   }
 
 


### PR DESCRIPTION
- changes exception thrown for an address already registered from `Directory#register` to a more specific one.
- implements `Stage#lookupOrStart` variants need for looking up or starting actors at specific addresses in lattice `Grid`.